### PR TITLE
[TUBEMQ-28] fix ignore path error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ target/
 !.gitignore
 !.gitkeep
 !.travis.yml
-tube-server/test/
+tubemq-server/src/test/


### PR DESCRIPTION
Fix path error in gitignore.
From `tube-server/test/` to `tubemq-server/src/test/`