### PR TITLE
[TUBEMQ-37] Offset is set to 0 when Broker goes offline

### DIFF
--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/mem/MsgMemStore.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/mem/MsgMemStore.java
@@ -371,7 +371,6 @@ public class MsgMemStore implements Closeable {
 
     @Override
     public void close() {
-        this.clear();
         ((DirectBuffer) this.cacheDataSegment).cleaner().clean();
         ((DirectBuffer) this.cachedIndexSegment).cleaner().clean();
     }


### PR DESCRIPTION
Calling clear () in close () is not necessary, and it is easy to cause data disorder.