### PR TITLE
[TUBEMQ-98] Fix typo & Simplify 'instanceof' judgment

### DIFF
--- a/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/BaseMessageConsumer.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/BaseMessageConsumer.java
@@ -1651,7 +1651,7 @@ public class BaseMessageConsumer implements MessageConsumer {
                                     logger.warn(strBuffer
                                             .append("[heart2broker error] certificate failure, ")
                                             .append(brokerInfo.getBrokerStrInfo())
-                                            .append("'s partitions ared released, ")
+                                            .append("'s partitions area released, ")
                                             .append(heartBeatResponseV2.getErrMsg()).toString());
                                     strBuffer.delete(0, strBuffer.length());
                                 }
@@ -1663,12 +1663,12 @@ public class BaseMessageConsumer implements MessageConsumer {
                                 samplePrintCtrl.printExceptionCaught(ee);
                                 if (!partStrSet.isEmpty()) {
                                     strBuffer.delete(0, strBuffer.length());
-                                    for (String partionStr : partStrSet) {
-                                        Partition tmpPartition = new Partition(partionStr);
+                                    for (String partitionStr : partStrSet) {
+                                        Partition tmpPartition = new Partition(partitionStr);
                                         removePartition(tmpPartition);
                                         logger.warn(strBuffer
                                                 .append("[heart2broker Throwable] release partition:")
-                                                .append(partionStr).toString());
+                                                .append(partitionStr).toString());
                                         strBuffer.delete(0, strBuffer.length());
                                     }
                                 }

--- a/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/ConsumerSamplePrint.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/ConsumerSamplePrint.java
@@ -17,7 +17,6 @@
 
 package org.apache.tubemq.client.consumer;
 
-import java.io.IOException;
 import org.apache.tubemq.corebase.utils.AbstractSamplePrint;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +41,7 @@ public class ConsumerSamplePrint extends AbstractSamplePrint {
         if (e == null) {
             return;
         }
-        if (e instanceof IOException || e instanceof Exception) {
+        if (e instanceof Exception) {
             final long now = System.currentTimeMillis();
             final long diffTime = now - lastLogTime.get();
             final long curPrintCnt = totalPrintCount.incrementAndGet();

--- a/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/RmtDataCache.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/RmtDataCache.java
@@ -488,13 +488,13 @@ public class RmtDataCache implements Closeable {
                         PartitionSelectResult partitionRet =
                                 new PartitionSelectResult(true, TErrCodeConstants.SUCCESS,
                                         "Ok!", partition, 0, lastPackConsumed);
-                        List<PartitionSelectResult> targetPartitonList =
+                        List<PartitionSelectResult> targetPartitionList =
                                 unNewRegisterInfoMap.get(entry.getKey());
-                        if (targetPartitonList == null) {
-                            targetPartitonList = new ArrayList<>();
-                            unNewRegisterInfoMap.put(entry.getKey(), targetPartitonList);
+                        if (targetPartitionList == null) {
+                            targetPartitionList = new ArrayList<>();
+                            unNewRegisterInfoMap.put(entry.getKey(), targetPartitionList);
                         }
-                        targetPartitonList.add(partitionRet);
+                        targetPartitionList.add(partitionRet);
                     }
                 }
             }
@@ -606,9 +606,9 @@ public class RmtDataCache implements Closeable {
                 unRegPartitionList.addAll(entry.getValue());
             } else {
                 boolean isNewBroker = true;
-                for (Partition regPartiton : entry.getValue()) {
-                    if (!partitionList.contains(regPartiton)) {
-                        unRegPartitionList.add(regPartiton);
+                for (Partition regPartition : entry.getValue()) {
+                    if (!partitionList.contains(regPartition)) {
+                        unRegPartitionList.add(regPartition);
                         isNewBroker = false;
                     }
                 }

--- a/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/RmtDataCache.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/RmtDataCache.java
@@ -280,7 +280,7 @@ public class RmtDataCache implements Closeable {
         return false;
     }
 
-    public Partition getPartitonByKey(String partitionKey) {
+    public Partition getPartitionByKey(String partitionKey) {
         return partitionMap.get(partitionKey);
     }
 

--- a/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/SimplePullMessageConsumer.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/SimplePullMessageConsumer.java
@@ -156,7 +156,7 @@ public class SimplePullMessageConsumer implements PullMessageConsumer {
                     "The confirmContext's value invalid!");
         }
         Partition curPartition =
-                baseConsumer.rmtDataCache.getPartitonByKey(keyId);
+                baseConsumer.rmtDataCache.getPartitionByKey(keyId);
         if (curPartition == null) {
             return new ConsumerResult(TErrCodeConstants.NOT_FOUND, sBuilder
                     .append("Not found the partition by confirmContext:")

--- a/tubemq-client/src/test/java/org/apache/tubemq/client/consumer/RmtDataCacheTest.java
+++ b/tubemq-client/src/test/java/org/apache/tubemq/client/consumer/RmtDataCacheTest.java
@@ -54,7 +54,7 @@ public class RmtDataCacheTest {
         assertEquals(1, brokerInfos.size());
         assertTrue(brokerInfos.contains(brokerInfo));
 
-        assertEquals(expectPartition.getPartitionId(), cache.getPartitonByKey("1:test:1").getBrokerId());
+        assertEquals(expectPartition.getPartitionId(), cache.getPartitionByKey("1:test:1").getBrokerId());
         cache.addPartition(new Partition(brokerInfo, "test", 2), 10);
         assertEquals(2, cache.getBrokerPartitionList(brokerInfo).size());
 


### PR DESCRIPTION
1. Fix type
ared -> area
partionStr -> partitionStr
getPartitonByKey -> getPartitionByKey

2. Simplify 'instanceof' judgment
This code
```
if (e instanceof IOException || e instanceof Exception) {
    //
}
```
It can be replaced by the following code
```
if (e instanceof Exception) {
    //
}
```