### PR TITLE
[TUBEMQ-102] Fix question [TUBEMQ-101] [Optimize code]

### DIFF
--- a/tubemq-core/src/main/java/org/apache/tubemq/corebase/cluster/MasterInfo.java
+++ b/tubemq-core/src/main/java/org/apache/tubemq/corebase/cluster/MasterInfo.java
@@ -71,7 +71,9 @@ public class MasterInfo {
             }
             int port = Integer.parseInt(hostPortItem[1].trim());
             NodeAddrInfo tmpNodeAddrInfo = new NodeAddrInfo(hostName, port);
-            addrMap4Failover.putIfAbsent(tmpNodeAddrInfo.getHostPortStr(), tmpNodeAddrInfo);
+            if (addrMap4Failover.get(tmpNodeAddrInfo.getHostPortStr()) == null) {
+                addrMap4Failover.put(tmpNodeAddrInfo.getHostPortStr(), tmpNodeAddrInfo);
+            }
             if (this.firstNodeAddr == null) {
                 this.firstNodeAddr = tmpNodeAddrInfo;
             }


### PR DESCRIPTION
Because the core module uses jdk1.7, this code cannot use 'putIfAbsent'
```
addrMap4Failover.putIfAbsent(tmpNodeAddrInfo.getHostPortStr(), tmpNodeAddrInfo);
```
We should use the original
```
if (addrMap4Failover.get(tmpNodeAddrInfo.getHostPortStr()) == null) {
    addrMap4Failover.put(tmpNodeAddrInfo.getHostPortStr(), tmpNodeAddrInfo);
}
```