### PR TITLE
[TUBEMQ-141] Remove the requirement to provide localHostIP

### DIFF
--- a/tubemq-client/src/main/java/org/apache/tubemq/client/config/ConsumerConfig.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/config/ConsumerConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -55,14 +55,23 @@ public class ConsumerConfig extends TubeClientConfig {
             TClientConstants.CFG_DEFAULT_PULL_PROTECT_CONFIRM_WAIT_PERIOD_MS;
     private boolean pullConfirmInLocal = false;
 
+    public ConsumerConfig(String masterAddrInfo, String consumerGroup) {
+        this(new MasterInfo(masterAddrInfo), consumerGroup);
+    }
 
-    public ConsumerConfig(String localHostIP, String masterAddrInfo,
-                          String consumerGroup) throws Exception {
-        super(localHostIP, masterAddrInfo);
+    public ConsumerConfig(MasterInfo masterInfo, String consumerGroup) {
+        super(masterInfo);
         validConsumerGroupParameter(consumerGroup);
         this.consumerGroup = consumerGroup.trim();
     }
 
+    @Deprecated
+    public ConsumerConfig(String localHostIP, String masterAddrInfo,
+                          String consumerGroup) throws Exception {
+        this(localHostIP, new MasterInfo(masterAddrInfo), consumerGroup);
+    }
+
+    @Deprecated
     public ConsumerConfig(String localHostIP, MasterInfo masterInfo,
                           String consumerGroup) throws Exception {
         super(localHostIP, masterInfo);

--- a/tubemq-client/src/main/java/org/apache/tubemq/client/config/TubeClientConfig.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/config/TubeClientConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -92,23 +92,26 @@ public class TubeClientConfig {
     // TLS configuration.
     private TLSConfig tlsConfig = new TLSConfig();
 
-
-    public TubeClientConfig(final String localHostIP, final String masterAddrInfo) throws Exception {
-        if (TStringUtils.isBlank(localHostIP)) {
-            throw new IllegalArgumentException("Illegal parameter: localHostIP is blank!");
-        }
-        // Not allow to set local host ip to 127.0.0.1.
-        if ("127.0.0.1".equals(localHostIP)) {
-            throw new IllegalArgumentException("Illegal parameter: localHostIP can't set to 127.0.0.1");
-        }
-        if (TStringUtils.isBlank(masterAddrInfo)) {
-            throw new IllegalArgumentException("Illegal parameter: masterAddrInfo is Blank!");
-        }
-        this.masterInfo = new MasterInfo(masterAddrInfo);
-        AddressUtils.validLocalIp(localHostIP.trim());
+    public TubeClientConfig(String masterAddrInfo) {
+        this(new MasterInfo(masterAddrInfo));
     }
 
-    public TubeClientConfig(final String localHostIP, final MasterInfo masterInfo) throws Exception {
+    public TubeClientConfig(MasterInfo masterInfo) {
+        if (masterInfo == null) {
+            throw new IllegalArgumentException("Illegal parameter: masterAddrInfo is null!");
+        }
+        this.masterInfo = masterInfo.clone();
+        String iPv4LocalAddress = AddressUtils.getIPV4LocalAddress();
+        AddressUtils.setLocalAddress(iPv4LocalAddress);
+    }
+
+    @Deprecated
+    public TubeClientConfig(final String localHostIP, final String masterAddrInfo) {
+        this(localHostIP, new MasterInfo(masterAddrInfo));
+    }
+
+    @Deprecated
+    public TubeClientConfig(final String localHostIP, final MasterInfo masterInfo) {
         if (TStringUtils.isBlank(localHostIP)) {
             throw new IllegalArgumentException("Illegal parameter: localHostIP is blank!");
         }

--- a/tubemq-core/src/main/java/org/apache/tubemq/corebase/exception/AddressException.java
+++ b/tubemq-core/src/main/java/org/apache/tubemq/corebase/exception/AddressException.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tubemq.corebase.exception;
+
+public class AddressException extends RuntimeException {
+
+    public AddressException() {
+        super();
+    }
+
+    public AddressException(String message, Throwable cause) {
+        super(message, cause);
+    }
+
+    public AddressException(String message) {
+        super(message);
+    }
+
+    public AddressException(Throwable cause) {
+        super(cause);
+    }
+
+}

--- a/tubemq-core/src/test/java/org/apache/tubemq/corebase/utils/AddressUtilsTest.java
+++ b/tubemq-core/src/test/java/org/apache/tubemq/corebase/utils/AddressUtilsTest.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.tubemq.corebase.utils;
+
+import junit.framework.TestCase;
+import org.junit.Assert;
+
+public class AddressUtilsTest extends TestCase {
+
+    public void test() {
+        String address = AddressUtils.getIPV4LocalAddress();
+        Assert.assertNotNull(address);
+    }
+
+}


### PR DESCRIPTION
1. Remove the requirement to provide localHostIP
2. Optimize the TubeClientConfig constructor to remove some explicit exceptions