### PR TITLE
[TUBEMQ-172] simplify start/stop script

### DIFF
--- a/bin/tubemq
+++ b/bin/tubemq
@@ -1,0 +1,163 @@
+#!/bin/bash
+
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# project directory
+if [ -z "$BASE_DIR" ] ; then
+  PRG="$0"
+
+  # need this for relative symlinks
+  while [ -h "$PRG" ] ; do
+    ls=`ls -ld "$PRG"`
+    link=`expr "$ls" : '.*-> \(.*\)$'`
+    if expr "$link" : '/.*' > /dev/null; then
+      PRG="$link"
+    else
+      PRG="`dirname "$PRG"`/$link"
+    fi
+  done
+  BASE_DIR=`dirname "$PRG"`/..
+
+  # make it fully qualified
+  BASE_DIR=`cd "$BASE_DIR" && pwd`
+fi
+
+# load environmental variables
+source $BASE_DIR/bin/env.sh
+
+AS_USER=`whoami`
+LOG_DIR="$BASE_DIR/logs"
+PID_DIR="$BASE_DIR/logs"
+
+# check service running status
+function running(){
+  if [ -f "$PID_FILE" ]; then
+    pid=$(cat "$PID_FILE")
+    process=`ps aux | grep " $pid "|grep "\-Dtubemq\.home=$BASE_DIR" | grep -v grep`;
+    if [ "$process" == "" ]; then
+      return 1;
+    else
+      return 0;
+    fi
+  else
+    return 1
+  fi
+}
+
+# start the specified service
+function start_server() {
+  if running; then
+    echo "TubeMQ $SERVICE is running."
+    exit 1
+  fi
+
+  mkdir -p $PID_DIR
+  touch $LOG_FILE
+  mkdir -p $LOG_DIR
+  chown -R $AS_USER $PID_DIR
+  chown -R $AS_USER $LOG_DIR
+
+  config_files="-f $BASE_DIR/conf/$SERVICE.ini"
+
+  echo "Starting TubeMQ $SERVICE server..."
+  pushd .
+    cd $BASE_DIR
+    #echo "$JAVA $SERVICE_ARGS $SERVICE_CLASS $config_files"
+    sleep 1
+    nohup $JAVA $SERVICE_ARGS $SERVICE_CLASS $config_files 2>&1 >>$LOG_FILE &
+    echo $! > $PID_FILE
+    chmod 755 $PID_FILE
+  popd
+}
+
+# stop the specified service
+function stop_server() {
+  if ! running; then
+    echo "TubeMQ $SERVICE is not running."
+    exit 1
+  fi
+  count=0
+  pid=$(cat $PID_FILE)
+  while running;
+  do
+    let count=$count+1
+    echo "Stopping TubeMQ $SERVICE $count times"
+    if [ $count -gt 10 ]; then
+      echo "kill -9 $pid"
+      kill -9 $pid
+    else
+      kill $pid
+    fi
+    sleep 6;
+  done
+  echo "Stop TubeMQ $SERVICE successfully."
+  rm $PID_FILE
+}
+
+# display usage
+function help() {
+  echo "Usage: tubemq {master|broker} {start|stop|restart}" >&2
+  echo "       start:      start the master/broker server"
+  echo "       stop:       stop the master/broker server"
+  echo "       restart:    restart the master/broker server"
+}
+
+# if less than two arguments supplied
+if [ $# -lt 2 ]; then
+  help;
+  exit 1;
+fi
+
+SERVICE=$1
+COMMAND=$2
+shift 2
+
+case $SERVICE in
+  master)
+    SERVICE_CLASS="org.apache.tubemq.server.tools.MasterStartup"
+    SERVICE_ARGS=$MASTER_ARGS
+    ;;
+  broker)
+    SERVICE_CLASS="org.apache.tubemq.server.tools.BrokerStartup"
+    SERVICE_ARGS=$BROKER_ARGS
+    ;;
+  *)
+    help;
+    exit 1;
+    ;;
+esac
+
+LOG_FILE="$LOG_DIR/$SERVICE.log"
+PID_FILE="$PID_DIR/.$SERVICE.run.pid"
+
+case $COMMAND in
+  start)
+    start_server $@;
+    ;;
+  stop)
+    stop_server $@;
+    ;;
+  restart)
+    $0 $SERVICE stop $@
+    $0 $SERVICE start $@
+    ;;
+  *)
+    help;
+    exit 1;
+    ;;
+esac

--- a/docs/tubemq_user_guide.md
+++ b/docs/tubemq_user_guide.md
@@ -152,7 +152,7 @@ Please notice that the master servers should be clock synchronized.
 After update the config file, please go to the `bin` folder and run this command to start
 the master service.
 ```bash
-./master.sh start
+./tubemq master start
 ```
 You should be able to access `http://your-master-ip:8080/config/topic_list.htm` to see the
 web GUI now.
@@ -178,7 +178,7 @@ Click the online link to activate the new added broker.
 
 Go to the broker server, under the `bin` folder run this command to start the broker service
 ```bash
-./broker.sh start
+./tubemq broker start
 ```
 
 Refresh the GUI broker list page, you can see that the broker now is registered.
@@ -186,6 +186,20 @@ Refresh the GUI broker list page, you can see that the broker now is registered.
 After the sub-state of the broker changed to `idle`, we can add topics to that broker.
 
 ![Add Broker 3](img/tubemq-add-broker-3.png)
+
+## Set Environment Variable (optional)
+We can set the path of TubeMQ to the environment variable for easy use.
+```bash
+TUBEMQ_HOME=/opt/tubemq-server
+PATH=$TUBEMQ_HOME/bin:$PATH
+```
+After that, we can use the following commands to start/stop and restart the master/broker service anywhere.
+```bash
+Usage: tubemq {master|broker} {start|stop|restart}
+       start:      start the master/broker server
+       stop:       stop the master/broker server
+       restart:    restart the master/broker server
+```
 
 ## Add Topic
 We can add or manage the cluster topics on the web GUI. To add a new topic, go to the


### PR DESCRIPTION
I merged the features of the 2 scripts (master.sh/broker.sh), which support commands to start, stop and restart on either the master or broker server.

When the directory path is added to the path environment variable, it works like this:
![image](https://user-images.githubusercontent.com/14295594/83543426-f3779300-a52e-11ea-8887-06052a343cd4.png)

I wonder if this solves the problem with this jira?