### PR TITLE
[TUBEMQ-197] Support TubeMQ connector of source for Apache Flink

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,7 @@
         <module>tubemq-client</module>
         <module>tubemq-server</module>
         <module>tubemq-example</module>
+        <module>tubemq-connectors</module>
     </modules>
 
     <properties>

--- a/tubemq-connectors/pom.xml
+++ b/tubemq-connectors/pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tubemq</artifactId>
+        <groupId>org.apache.tubemq</groupId>
+        <version>0.5.0-incubating-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <name>Apache TubeMQ - Connectors</name>
+    <artifactId>tubemq-connectors</artifactId>
+    <packaging>pom</packaging>
+    <modules>
+        <module>tubemq-connector-flink</module>
+    </modules>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tubemq</groupId>
+            <artifactId>tubemq-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tubemq</groupId>
+            <artifactId>tubemq-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                    <encoding>UTF-8</encoding>
+                    <showDeprecation>true</showDeprecation>
+                    <showWarnings>true</showWarnings>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tubemq-connectors/tubemq-connector-flink/pom.xml
+++ b/tubemq-connectors/tubemq-connector-flink/pom.xml
@@ -1,0 +1,105 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+-->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>tubemq-connectors</artifactId>
+        <groupId>org.apache.tubemq</groupId>
+        <version>0.5.0-incubating-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+    <name>Apache TubeMQ - Connectors-flink</name>
+    <artifactId>tubemq-connector-flink</artifactId>
+
+    <properties>
+        <flink.version>1.9.2</flink.version>
+        <scala.binary.version>2.11</scala.binary.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.tubemq</groupId>
+            <artifactId>tubemq-client</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.tubemq</groupId>
+            <artifactId>tubemq-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-core</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-runtime_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-streaming-java_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-api-java-bridge_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-common</artifactId>
+            <version>${flink.version}</version>
+            <scope>test</scope>
+            <type>test-jar</type>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/Tubemq.java
+++ b/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/Tubemq.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.tubemq;
+
+import static org.apache.flink.connectors.tubemq.TubemqValidator.CONNECTOR_GROUP;
+import static org.apache.flink.connectors.tubemq.TubemqValidator.CONNECTOR_MASTER;
+import static org.apache.flink.connectors.tubemq.TubemqValidator.CONNECTOR_PROPERTIES;
+import static org.apache.flink.connectors.tubemq.TubemqValidator.CONNECTOR_TIDS;
+import static org.apache.flink.connectors.tubemq.TubemqValidator.CONNECTOR_TOPIC;
+import static org.apache.flink.connectors.tubemq.TubemqValidator.CONNECTOR_TYPE_VALUE_TUBEMQ;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.flink.table.descriptors.ConnectorDescriptor;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+
+/**
+ * The {@link ConnectorDescriptor} for tubemq sources and sinks.
+ */
+public class Tubemq extends ConnectorDescriptor {
+
+    @Nullable
+    private String topic;
+
+    @Nullable
+    private String master;
+
+    @Nullable
+    private String group;
+
+    @Nullable
+    private String tids;
+
+    @Nonnull
+    private Map<String, String> properties;
+
+    public Tubemq() {
+        super(CONNECTOR_TYPE_VALUE_TUBEMQ, 1, true);
+
+        this.properties = new HashMap<>();
+    }
+
+    /**
+     * Sets the tubemq topic to be used.
+     *
+     * @param topic The topic name.
+     */
+    public Tubemq topic(String topic) {
+        checkNotNull(topic);
+
+        this.topic = topic;
+        return this;
+    }
+
+    /**
+     * Sets the address of tubemq master to connect.
+     *
+     * @param master The address of tubemq master.
+     */
+    public Tubemq master(String master) {
+        checkNotNull(master);
+
+        this.master = master;
+        return this;
+    }
+
+    /**
+     * Sets the tubemq (consumer or producer) group to be used.
+     *
+     * @param group The group name.
+     */
+    public Tubemq group(String group) {
+        checkNotNull(group);
+
+        this.group = group;
+        return this;
+    }
+
+    /**
+     * The tubemq consumers use these tids to filter records reading from server.
+     *
+     * @param tids The filter for consume record from server.
+     */
+    public Tubemq tids(String tids) {
+
+        this.tids = tids;
+        return this;
+    }
+
+    /**
+     * Sets the tubemq property.
+     *
+     * @param key   The key of the property.
+     * @param value The value of the property.
+     */
+    public Tubemq property(String key, String value) {
+        checkNotNull(key);
+        checkNotNull(value);
+
+        properties.put(key, value);
+        return this;
+    }
+
+    @Override
+    protected Map<String, String> toConnectorProperties() {
+        DescriptorProperties descriptorProperties = new DescriptorProperties();
+
+        if (topic != null) {
+            descriptorProperties.putString(CONNECTOR_TOPIC, topic);
+        }
+
+        if (master != null) {
+            descriptorProperties.putString(CONNECTOR_MASTER, master);
+        }
+
+        if (group != null) {
+            descriptorProperties.putString(CONNECTOR_GROUP, group);
+        }
+
+        if (tids != null) {
+            descriptorProperties.putString(CONNECTOR_TIDS, tids);
+        }
+
+        descriptorProperties.putPropertiesWithPrefix(CONNECTOR_PROPERTIES, properties);
+
+        return descriptorProperties.asMap();
+    }
+}

--- a/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/TubemqOptions.java
+++ b/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/TubemqOptions.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.tubemq;
+
+import org.apache.flink.configuration.ConfigOption;
+import org.apache.flink.configuration.ConfigOptions;
+
+/**
+ * The configuration options for tubemq sources and sink.
+ */
+public class TubemqOptions {
+
+    public static final ConfigOption<String> SESSION_KEY =
+        ConfigOptions.key("session.key")
+            .noDefaultValue()
+            .withDescription("The session key for this consumer group at startup.");
+
+    public static final ConfigOption<Boolean> BOOTSTRAP_FROM_MAX =
+        ConfigOptions.key("bootstrap.from.max")
+            .defaultValue(false)
+            .withDescription("True if consuming from the most recent " +
+                "position when the tubemq source starts.. It only takes " +
+                "effect when the tubemq source does not recover from " +
+                "checkpoints.");
+
+    public static final ConfigOption<String> SOURCE_MAX_IDLE_TIME =
+        ConfigOptions.key("source.task.max.idle.time")
+            .defaultValue("5min")
+            .withDescription("The max time of the source marked as temporarily idle.");
+
+    public static final ConfigOption<String> MESSAGE_NOT_FOUND_WAIT_PERIOD =
+        ConfigOptions.key("message.not.found.wait.period")
+            .defaultValue("350ms")
+            .withDescription("The time of waiting period if tubemq broker return message not found.");
+}

--- a/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/TubemqSourceFunction.java
+++ b/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/TubemqSourceFunction.java
@@ -1,0 +1,351 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.tubemq;
+
+import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.LONG_TYPE_INFO;
+import static org.apache.flink.api.common.typeinfo.BasicTypeInfo.STRING_TYPE_INFO;
+import static org.apache.flink.runtime.net.ConnectionUtils.findConnectingAddress;
+import static org.apache.flink.util.Preconditions.checkNotNull;
+import static org.apache.flink.util.TimeUtils.parseDuration;
+
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeSet;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.state.OperatorStateStore;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.api.java.tuple.Tuple2;
+import org.apache.flink.api.java.typeutils.TupleTypeInfo;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.runtime.state.FunctionInitializationContext;
+import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
+import org.apache.tubemq.client.config.ConsumerConfig;
+import org.apache.tubemq.client.consumer.ConsumerResult;
+import org.apache.tubemq.client.consumer.PullMessageConsumer;
+import org.apache.tubemq.client.factory.TubeSingleSessionFactory;
+import org.apache.tubemq.corebase.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * The Flink tubemq Consumer.
+ *
+ * @param <T> The type of records produced by this data source
+ */
+public class TubemqSourceFunction<T>
+    extends RichParallelSourceFunction<T> implements CheckpointedFunction {
+
+    private static final Logger LOG =
+        LoggerFactory.getLogger(TubemqSourceFunction.class);
+
+    private static final String TUBE_OFFSET_STATE = "tube-offset-state";
+
+    private static final String SPLIT_COMMA = ",";
+    private static final String SPLIT_COLON = ":";
+
+    /**
+     * The address of tubemq master, format eg: 127.0.0.1:8080,127.0.0.2:8081.
+     */
+    private final String masterAddress;
+
+    /**
+     * The topic name.
+     */
+    private final String topic;
+
+    /**
+     * The tubemq consumers use this tid set to filter records reading from server.
+     */
+    private final TreeSet<String> tidSet;
+
+    /**
+     * The consumer group name.
+     */
+    private final String consumerGroup;
+
+    /**
+     * The deserializer for records.
+     */
+    private final DeserializationSchema<T> deserializationSchema;
+
+    /**
+     * The random key for tubemq consumer group when startup.
+     */
+    private final String sessionKey;
+
+    /**
+     * True if consuming message from max offset.
+     */
+    private final boolean consumeFromMax;
+
+    /**
+     * The time to wait if tubemq broker returns message not found.
+     */
+    private final Duration messageNotFoundWaitPeriod;
+
+    /**
+     * The max time to marked source idle.
+     */
+    private final Duration maxIdleTime;
+
+    /**
+     * Flag indicating whether the consumer is still running.
+     **/
+    private volatile boolean running;
+
+    /**
+     * The state for the offsets of queues.
+     */
+    private transient ListState<Tuple2<String, Long>> offsetsState;
+
+    /**
+     * The current offsets of partitions which are stored in {@link #offsetsState}
+     * once a checkpoint is triggered.
+     *
+     * <p>NOTE: The offsets are populated in the main thread and saved in the
+     * checkpoint thread. Its usage must be guarded by the checkpoint lock.</p>
+     */
+    private transient Map<String, Long> currentOffsets;
+
+    /**
+     * The tubemq session factory.
+     */
+    private transient TubeSingleSessionFactory messageSessionFactory;
+
+    /**
+     * The tubemq pull consumer.
+     */
+    private transient PullMessageConsumer messagePullConsumer;
+
+    public TubemqSourceFunction(
+        String masterAddress,
+        String topic,
+        TreeSet<String> tidSet,
+        String consumerGroup,
+        DeserializationSchema<T> deserializationSchema,
+        Configuration configuration
+    ) {
+        checkNotNull(masterAddress,
+            "The master address must not be null.");
+        checkNotNull(topic,
+            "The topic must not be null.");
+        checkNotNull(tidSet,
+            "The tid set must not be null.");
+        checkNotNull(consumerGroup,
+            "The consumer group must not be null.");
+        checkNotNull(deserializationSchema,
+            "The deserialization schema must not be null.");
+        checkNotNull(configuration,
+            "The configuration must not be null.");
+
+        this.masterAddress = masterAddress;
+        this.topic = topic;
+        this.tidSet = tidSet;
+        this.consumerGroup = consumerGroup;
+        this.deserializationSchema = deserializationSchema;
+
+        this.sessionKey =
+            configuration.getString(TubemqOptions.SESSION_KEY);
+        this.consumeFromMax =
+            configuration.getBoolean(TubemqOptions.BOOTSTRAP_FROM_MAX);
+        this.messageNotFoundWaitPeriod =
+            parseDuration(
+                configuration.getString(
+                    TubemqOptions.MESSAGE_NOT_FOUND_WAIT_PERIOD));
+        this.maxIdleTime =
+            parseDuration(
+                configuration.getString(
+                    TubemqOptions.SOURCE_MAX_IDLE_TIME));
+    }
+
+    @Override
+    public void initializeState(
+        FunctionInitializationContext context
+    ) throws Exception {
+
+        TypeInformation<Tuple2<String, Long>> typeInformation =
+            new TupleTypeInfo<>(STRING_TYPE_INFO, LONG_TYPE_INFO);
+        ListStateDescriptor<Tuple2<String, Long>> stateDescriptor =
+            new ListStateDescriptor<>(TUBE_OFFSET_STATE, typeInformation);
+
+        OperatorStateStore stateStore = context.getOperatorStateStore();
+        offsetsState = stateStore.getListState(stateDescriptor);
+
+        currentOffsets = new HashMap<>();
+        if (context.isRestored()) {
+            for (Tuple2<String, Long> tubeOffset : offsetsState.get()) {
+                currentOffsets.put(tubeOffset.f0, tubeOffset.f1);
+            }
+
+            LOG.info("Successfully restore the offsets {}.", currentOffsets);
+        } else {
+            LOG.info("No restore offsets.");
+        }
+    }
+
+    @Override
+    public void open(Configuration parameters) throws Exception {
+
+        String firstAddress = masterAddress.split(SPLIT_COMMA)[0];
+        String[] firstAddressSegments = firstAddress.split(SPLIT_COLON);
+        String firstHost = firstAddressSegments[0];
+        int firstPort = Integer.parseInt(firstAddressSegments[1]);
+        InetSocketAddress firstSocketAddress =
+            new InetSocketAddress(firstHost, firstPort);
+
+        InetAddress localAddress =
+            findConnectingAddress(firstSocketAddress, 2000, 400);
+        String localhost = localAddress.getHostAddress();
+
+        ConsumerConfig consumerConfig =
+            new ConsumerConfig(localhost, masterAddress, consumerGroup);
+        consumerConfig
+            .setConsumeModel(consumeFromMax ? 1 : 0);
+        consumerConfig
+            .setMsgNotFoundWaitPeriodMs(messageNotFoundWaitPeriod.toMillis());
+
+        int numTasks = getRuntimeContext().getNumberOfParallelSubtasks();
+
+        messageSessionFactory = new TubeSingleSessionFactory(consumerConfig);
+
+        messagePullConsumer =
+            messageSessionFactory.createPullConsumer(consumerConfig);
+        messagePullConsumer
+            .subscribe(topic, tidSet);
+        messagePullConsumer
+            .completeSubscribe(sessionKey, numTasks, true, currentOffsets);
+
+        running = true;
+    }
+
+    @Override
+    public void run(SourceContext<T> ctx) throws Exception {
+
+        Instant lastConsumeInstant = Instant.now();
+
+        while (running) {
+
+            ConsumerResult consumeResult = messagePullConsumer.getMessage();
+            if (!consumeResult.isSuccess()) {
+                LOG.info("Could not consume messages from tubemq (errcode: {}, " +
+                        "errmsg: {}).", consumeResult.getErrCode(),
+                    consumeResult.getErrMsg());
+
+                Duration idleTime =
+                    Duration.between(lastConsumeInstant, Instant.now());
+                if (idleTime.compareTo(maxIdleTime) > 0) {
+                    LOG.info("Mark this source as temporarily idle.");
+                    ctx.markAsTemporarilyIdle();
+                }
+
+                continue;
+            }
+
+            List<Message> messageList = consumeResult.getMessageList();
+
+            List<T> records = new ArrayList<>();
+            if (messageList != null) {
+                lastConsumeInstant = Instant.now();
+
+                for (Message message : messageList) {
+                    T record =
+                        deserializationSchema.deserialize(message.getData());
+                    records.add(record);
+                }
+            }
+
+            synchronized (ctx.getCheckpointLock()) {
+
+                for (T record : records) {
+                    ctx.collect(record);
+                }
+
+                currentOffsets.put(
+                    consumeResult.getPartitionKey(),
+                    consumeResult.getCurrOffset()
+                );
+            }
+
+            ConsumerResult confirmResult =
+                messagePullConsumer
+                    .confirmConsume(consumeResult.getConfirmContext(), true);
+            if (!confirmResult.isSuccess()) {
+                LOG.warn("Could not confirm messages to tubemq (errcode: {}, " +
+                        "errmsg: {}).", confirmResult.getErrCode(),
+                    confirmResult.getErrMsg());
+            }
+        }
+    }
+
+    @Override
+    public void snapshotState(FunctionSnapshotContext context) throws Exception {
+
+        offsetsState.clear();
+        for (Map.Entry<String, Long> entry : currentOffsets.entrySet()) {
+            offsetsState.add(new Tuple2<>(entry.getKey(), entry.getValue()));
+        }
+
+        LOG.info("Successfully save the offsets in checkpoint {}: {}.",
+            context.getCheckpointId(), currentOffsets);
+    }
+
+    @Override
+    public void cancel() {
+        running = false;
+    }
+
+    @Override
+    public void close() throws Exception {
+
+        cancel();
+
+        if (messagePullConsumer != null) {
+            try {
+                messagePullConsumer.shutdown();
+            } catch (Throwable t) {
+                LOG.warn("Could not properly shutdown the tubemq pull consumer.",
+                    t);
+            }
+        }
+
+        if (messageSessionFactory != null) {
+            try {
+                messageSessionFactory.shutdown();
+            } catch (Throwable t) {
+                LOG.warn("Could not properly shutdown the tubemq session " +
+                    "factory.", t);
+            }
+        }
+
+        super.close();
+
+        LOG.info("Closed the tubemq source.");
+    }
+}

--- a/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/TubemqTableSource.java
+++ b/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/TubemqTableSource.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.tubemq;
+
+import static org.apache.flink.util.Preconditions.checkNotNull;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeSet;
+
+import javax.annotation.Nullable;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
+import org.apache.flink.streaming.api.functions.source.SourceFunction;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.api.Types;
+import org.apache.flink.table.api.ValidationException;
+import org.apache.flink.table.sources.DefinedFieldMapping;
+import org.apache.flink.table.sources.DefinedProctimeAttribute;
+import org.apache.flink.table.sources.DefinedRowtimeAttributes;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
+import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.types.Row;
+
+/**
+ * Tubemq {@link StreamTableSource}.
+ */
+public class TubemqTableSource implements
+    StreamTableSource<Row>,
+    DefinedProctimeAttribute,
+    DefinedRowtimeAttributes,
+    DefinedFieldMapping {
+
+    /**
+     * Deserialization schema for records from tubemq.
+     */
+    private final DeserializationSchema<Row> deserializationSchema;
+
+    /**
+     * The schema of the table.
+     */
+    private final TableSchema schema;
+
+    /**
+     * Field name of the processing time attribute, null if no processing time
+     * field is defined.
+     */
+    private final Optional<String> proctimeAttribute;
+
+    /**
+     * Descriptors for rowtime attributes.
+     */
+    private final List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors;
+
+    /**
+     * Mapping for the fields of the table schema to fields of the physical
+     * returned type.
+     */
+    private final Map<String, String> fieldMapping;
+
+    /**
+     * The address of tubemq master, format eg: 127.0.0.1:8080,127.0.0.2:8081 .
+     */
+    private final String masterAddress;
+
+    /**
+     * The tubemq topic name.
+     */
+    private final String topic;
+
+    /**
+     * The tubemq tid filter collection.
+     */
+    private final TreeSet<String> tidSet;
+
+    /**
+     * The tubemq consumer group name.
+     */
+    private final String consumerGroup;
+
+    /**
+     * The parameters collection for tubemq consumer.
+     */
+    private final Configuration configuration;
+
+    public TubemqTableSource(
+        DeserializationSchema<Row> deserializationSchema,
+        TableSchema schema,
+        Optional<String> proctimeAttribute,
+        List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors,
+        Map<String, String> fieldMapping,
+        String masterAddress,
+        String topic,
+        TreeSet<String> tidSet,
+        String consumerGroup,
+        Configuration configuration
+    ) {
+        checkNotNull(deserializationSchema,
+            "The deserialization schema must not be null.");
+        checkNotNull(schema,
+            "The schema must not be null.");
+        checkNotNull(fieldMapping,
+            "The field mapping must not be null.");
+        checkNotNull(masterAddress,
+            "The master address must not be null.");
+        checkNotNull(topic,
+            "The topic must not be null.");
+        checkNotNull(tidSet,
+            "The tid set must not be null.");
+        checkNotNull(consumerGroup,
+            "The consumer group must not be null.");
+        checkNotNull(configuration,
+            "The configuration must not be null.");
+
+        this.deserializationSchema = deserializationSchema;
+        this.schema = schema;
+        this.fieldMapping = fieldMapping;
+        this.masterAddress = masterAddress;
+        this.topic = topic;
+        this.tidSet = tidSet;
+        this.consumerGroup = consumerGroup;
+        this.configuration = configuration;
+
+        this.proctimeAttribute =
+            validateProcTimeAttribute(proctimeAttribute);
+        this.rowtimeAttributeDescriptors =
+            validateRowTimeAttributeDescriptors(rowtimeAttributeDescriptors);
+    }
+
+    @Override
+    public TableSchema getTableSchema() {
+        return schema;
+    }
+
+    @Nullable
+    @Override
+    public String getProctimeAttribute() {
+        return proctimeAttribute.orElse(null);
+    }
+
+    @Override
+    public List<RowtimeAttributeDescriptor> getRowtimeAttributeDescriptors() {
+        return rowtimeAttributeDescriptors;
+    }
+
+    @Override
+    public Map<String, String> getFieldMapping() {
+        return fieldMapping;
+    }
+
+    @Override
+    public DataStream<Row> getDataStream(
+        StreamExecutionEnvironment streamExecutionEnvironment
+    ) {
+        SourceFunction<Row> sourceFunction =
+            new TubemqSourceFunction<>(
+                masterAddress,
+                topic,
+                tidSet,
+                consumerGroup,
+                deserializationSchema,
+                configuration
+            );
+
+        return streamExecutionEnvironment
+            .addSource(sourceFunction)
+            .name(explainSource());
+    }
+
+    private Optional<String> validateProcTimeAttribute(
+        Optional<String> proctimeAttribute
+    ) {
+        return proctimeAttribute.map((attribute) -> {
+            Optional<TypeInformation<?>> tpe = schema.getFieldType(attribute);
+            if (!tpe.isPresent()) {
+                throw new ValidationException("Proc time attribute '" +
+                    attribute + "' isn't present in TableSchema.");
+            } else if (tpe.get() != Types.SQL_TIMESTAMP()) {
+                throw new ValidationException("Proc time attribute '" +
+                    attribute + "' isn't of type SQL_TIMESTAMP.");
+            }
+            return attribute;
+        });
+    }
+
+    private List<RowtimeAttributeDescriptor> validateRowTimeAttributeDescriptors(
+        List<RowtimeAttributeDescriptor> attributeDescriptors
+    ) {
+        checkNotNull(attributeDescriptors);
+
+        for (RowtimeAttributeDescriptor desc : attributeDescriptors) {
+            String name = desc.getAttributeName();
+            Optional<TypeInformation<?>> tpe = schema.getFieldType(name);
+            if (!tpe.isPresent()) {
+                throw new ValidationException("Row time attribute '" + name +
+                    "' is not present.");
+            } else if (tpe.get() != Types.SQL_TIMESTAMP()) {
+                throw new ValidationException("Row time attribute '" + name +
+                    "' is not of type SQL_TIMESTAMP.");
+            }
+        }
+
+        return attributeDescriptors;
+    }
+}

--- a/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/TubemqTableSourceFactory.java
+++ b/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/TubemqTableSourceFactory.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.tubemq;
+
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_PROPERTY_VERSION;
+import static org.apache.flink.table.descriptors.ConnectorDescriptorValidator.CONNECTOR_TYPE;
+import static org.apache.flink.table.descriptors.FormatDescriptorValidator.FORMAT;
+import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_CLASS;
+import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_FROM;
+import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_SERIALIZED;
+import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_TIMESTAMPS_TYPE;
+import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_WATERMARKS_CLASS;
+import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_WATERMARKS_DELAY;
+import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_WATERMARKS_SERIALIZED;
+import static org.apache.flink.table.descriptors.Rowtime.ROWTIME_WATERMARKS_TYPE;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA_FROM;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA_NAME;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA_PROCTIME;
+import static org.apache.flink.table.descriptors.Schema.SCHEMA_TYPE;
+import static org.apache.flink.table.descriptors.StreamTableDescriptorValidator.UPDATE_MODE;
+import static org.apache.flink.table.descriptors.StreamTableDescriptorValidator.UPDATE_MODE_VALUE_APPEND;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.TreeSet;
+
+import org.apache.flink.api.common.serialization.DeserializationSchema;
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.table.api.TableSchema;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.SchemaValidator;
+import org.apache.flink.table.factories.DeserializationSchemaFactory;
+import org.apache.flink.table.factories.StreamTableSourceFactory;
+import org.apache.flink.table.factories.TableFactoryService;
+import org.apache.flink.table.sources.RowtimeAttributeDescriptor;
+import org.apache.flink.table.sources.StreamTableSource;
+import org.apache.flink.types.Row;
+
+/**
+ * Factory for creating configured instances of {@link TubemqTableSource}.
+ */
+public class TubemqTableSourceFactory implements StreamTableSourceFactory<Row> {
+
+    private static final String SPLIT_COMMA = ",";
+
+    private TubemqTableSourceFactory() {
+    }
+
+    @Override
+    public Map<String, String> requiredContext() {
+
+        Map<String, String> context = new HashMap<>();
+        context.put(UPDATE_MODE, UPDATE_MODE_VALUE_APPEND);
+        context.put(CONNECTOR_TYPE, TubemqValidator.CONNECTOR_TYPE_VALUE_TUBEMQ);
+        context.put(CONNECTOR_PROPERTY_VERSION, "1");
+
+        return context;
+    }
+
+    @Override
+    public List<String> supportedProperties() {
+        List<String> properties = new ArrayList<>();
+
+        // tubemq
+        properties.add(TubemqValidator.CONNECTOR_TOPIC);
+        properties.add(TubemqValidator.CONNECTOR_MASTER);
+        properties.add(TubemqValidator.CONNECTOR_GROUP);
+        properties.add(TubemqValidator.CONNECTOR_TIDS);
+        properties.add(TubemqValidator.CONNECTOR_PROPERTIES + ".*");
+
+        // schema
+        properties.add(SCHEMA + ".#." + SCHEMA_TYPE);
+        properties.add(SCHEMA + ".#." + SCHEMA_NAME);
+        properties.add(SCHEMA + ".#." + SCHEMA_FROM);
+
+        // time attributes
+        properties.add(SCHEMA + ".#." + SCHEMA_PROCTIME);
+        properties.add(SCHEMA + ".#." + ROWTIME_TIMESTAMPS_TYPE);
+        properties.add(SCHEMA + ".#." + ROWTIME_TIMESTAMPS_FROM);
+        properties.add(SCHEMA + ".#." + ROWTIME_TIMESTAMPS_CLASS);
+        properties.add(SCHEMA + ".#." + ROWTIME_TIMESTAMPS_SERIALIZED);
+        properties.add(SCHEMA + ".#." + ROWTIME_WATERMARKS_TYPE);
+        properties.add(SCHEMA + ".#." + ROWTIME_WATERMARKS_CLASS);
+        properties.add(SCHEMA + ".#." + ROWTIME_WATERMARKS_SERIALIZED);
+        properties.add(SCHEMA + ".#." + ROWTIME_WATERMARKS_DELAY);
+
+        // format wildcard
+        properties.add(FORMAT + ".*");
+
+        return properties;
+    }
+
+    @Override
+    public StreamTableSource<Row> createStreamTableSource(
+        Map<String, String> properties
+    ) {
+        final DeserializationSchema<Row> deserializationSchema =
+            getDeserializationSchema(properties);
+
+        final DescriptorProperties descriptorProperties =
+            new DescriptorProperties(true);
+        descriptorProperties.putProperties(properties);
+
+        validateProperties(descriptorProperties);
+
+        final TableSchema schema =
+            descriptorProperties.getTableSchema(SCHEMA);
+        final Optional<String> proctimeAttribute =
+            SchemaValidator.deriveProctimeAttribute(descriptorProperties);
+        final List<RowtimeAttributeDescriptor> rowtimeAttributeDescriptors =
+            SchemaValidator.deriveRowtimeAttributes(descriptorProperties);
+        final Map<String, String> fieldMapping =
+            SchemaValidator.deriveFieldMapping(
+                descriptorProperties,
+                Optional.of(deserializationSchema.getProducedType()));
+        final String topic =
+            descriptorProperties.getString(TubemqValidator.CONNECTOR_TOPIC);
+        final String masterAddress =
+            descriptorProperties.getString(TubemqValidator.CONNECTOR_MASTER);
+        final String consumerGroup =
+            descriptorProperties.getString(TubemqValidator.CONNECTOR_GROUP);
+        final String tids =
+            descriptorProperties
+                .getOptionalString(TubemqValidator.CONNECTOR_TIDS)
+                .orElse(null);
+        final Configuration configuration =
+            getConfiguration(descriptorProperties);
+
+        TreeSet<String> tidSet = new TreeSet<>();
+        if (tids != null) {
+            tidSet.addAll(Arrays.asList(tids.split(SPLIT_COMMA)));
+        }
+
+        return new TubemqTableSource(
+            deserializationSchema,
+            schema,
+            proctimeAttribute,
+            rowtimeAttributeDescriptors,
+            fieldMapping,
+            masterAddress,
+            topic,
+            tidSet,
+            consumerGroup,
+            configuration
+        );
+    }
+
+    private void validateProperties(DescriptorProperties descriptorProperties) {
+        new SchemaValidator(true, false, false).validate(descriptorProperties);
+        new TubemqValidator().validate(descriptorProperties);
+    }
+
+    private DeserializationSchema<Row> getDeserializationSchema(
+        Map<String, String> properties
+    ) {
+        @SuppressWarnings("unchecked") final DeserializationSchemaFactory<Row> formatFactory =
+            TableFactoryService.find(
+                DeserializationSchemaFactory.class,
+                properties,
+                this.getClass().getClassLoader()
+            );
+
+        return formatFactory.createDeserializationSchema(properties);
+    }
+
+    private Configuration getConfiguration(
+        DescriptorProperties descriptorProperties
+    ) {
+        Map<String, String> properties =
+            descriptorProperties.getPropertiesWithPrefix(TubemqValidator.CONNECTOR_PROPERTIES);
+
+        Configuration configuration = new Configuration();
+        for (Map.Entry<String, String> property : properties.entrySet()) {
+            configuration.setString(property.getKey(), property.getValue());
+        }
+
+        return configuration;
+    }
+}

--- a/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/TubemqValidator.java
+++ b/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/TubemqValidator.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.tubemq;
+
+import org.apache.flink.table.descriptors.ConnectorDescriptorValidator;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+
+/**
+ * The validator for {@link Tubemq}.
+ */
+public class TubemqValidator extends ConnectorDescriptorValidator {
+
+    /**
+     * The type of connector.
+     */
+    public static final String CONNECTOR_TYPE_VALUE_TUBEMQ = "tubemq";
+
+    /**
+     * The address of tubemq master.
+     */
+    public static final String CONNECTOR_MASTER = "connector.master";
+
+    /**
+     * The tubemq topic name.
+     */
+    public static final String CONNECTOR_TOPIC = "connector.topic";
+
+    /**
+     * The tubemq (consumer or producer) group name.
+     */
+    public static final String CONNECTOR_GROUP = "connector.group";
+
+    /**
+     * The tubemq consumers use these tids to filter records reading from server.
+     */
+    public static final String CONNECTOR_TIDS = "connector.tids";
+
+    /**
+     * The prefix of tubemq properties (optional).
+     */
+    public static final String CONNECTOR_PROPERTIES = "connector.properties";
+
+    @Override
+    public void validate(DescriptorProperties properties) {
+        super.validate(properties);
+
+        // Validates that the connector type is tubemq.
+        properties.validateValue(CONNECTOR_TYPE, CONNECTOR_TYPE_VALUE_TUBEMQ, false);
+
+        // Validate that the topic name is set.
+        properties.validateString(CONNECTOR_TOPIC, false, 1, Integer.MAX_VALUE);
+
+        // Validate that the master address is set.
+        properties.validateString(CONNECTOR_MASTER, false, 1, Integer.MAX_VALUE);
+
+        // Validate that the group name is set.
+        properties.validateString(CONNECTOR_GROUP, false, 1, Integer.MAX_VALUE);
+
+        // Validate that the tids is set.
+        properties.validateString(CONNECTOR_TIDS, true, 1, Integer.MAX_VALUE);
+    }
+}

--- a/tubemq-connectors/tubemq-connector-flink/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
+++ b/tubemq-connectors/tubemq-connector-flink/src/main/resources/META-INF/services/org.apache.flink.table.factories.TableFactory
@@ -1,0 +1,16 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+org.apache.flink.connectors.tubemq.TubemqTableSourceFactory

--- a/tubemq-connectors/tubemq-connector-flink/src/test/java/org/apache/flink/connectors/tubemq/TubemqTest.java
+++ b/tubemq-connectors/tubemq-connector-flink/src/test/java/org/apache/flink/connectors/tubemq/TubemqTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connectors.tubemq;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.flink.table.descriptors.Descriptor;
+import org.apache.flink.table.descriptors.DescriptorProperties;
+import org.apache.flink.table.descriptors.DescriptorTestBase;
+import org.apache.flink.table.descriptors.DescriptorValidator;
+import org.junit.Test;
+
+/**
+ * Unit tests for {@link Tubemq}.
+ */
+public class TubemqTest extends DescriptorTestBase {
+
+    @Override
+    protected List<Descriptor> descriptors() {
+        final Descriptor descriptor1 =
+            new Tubemq()
+                .topic("test-topic-1")
+                .master("localhost:9001")
+                .group("test-group-1");
+
+        final Descriptor descriptor2 =
+            new Tubemq()
+                .topic("test-topic-2")
+                .master("localhost:9001")
+                .group("test-group-2")
+                .property("bootstrap.from.max", "true");
+
+        final Descriptor descriptor3 =
+            new Tubemq()
+                .topic("test-topic-3")
+                .master("localhost:9001")
+                .group("test-group-3")
+                .tids("test-tid-1,test-tid-2");
+
+        return Arrays.asList(descriptor1, descriptor2, descriptor3);
+    }
+
+    @Override
+    protected List<Map<String, String>> properties() {
+        final Map<String, String> props1 = new HashMap<>();
+        props1.put("connector.property-version", "1");
+        props1.put("connector.type", "tubemq");
+        props1.put("connector.master", "localhost:9001");
+        props1.put("connector.topic", "test-topic-1");
+        props1.put("connector.group", "test-group-1");
+
+        final Map<String, String> props2 = new HashMap<>();
+        props2.put("connector.property-version", "1");
+        props2.put("connector.type", "tubemq");
+        props2.put("connector.master", "localhost:9001");
+        props2.put("connector.topic", "test-topic-2");
+        props2.put("connector.group", "test-group-2");
+        props2.put("connector.properties.bootstrap.from.max", "true");
+
+        final Map<String, String> props3 = new HashMap<>();
+        props3.put("connector.property-version", "1");
+        props3.put("connector.type", "tubemq");
+        props3.put("connector.master", "localhost:9001");
+        props3.put("connector.topic", "test-topic-3");
+        props3.put("connector.tids", "test-tid-1,test-tid-2");
+        props3.put("connector.group", "test-group-3");
+
+        return Arrays.asList(props1, props2, props3);
+    }
+
+    @Override
+    protected DescriptorValidator validator() {
+        return new TubemqValidator();
+    }
+
+    @Test
+    public void testTubePropertiesValidator() {
+        DescriptorValidator validator = this.validator();
+        DescriptorProperties descriptorProperties = new DescriptorProperties();
+        descriptorProperties.putProperties(properties().get(0));
+        validator.validate(descriptorProperties);
+    }
+}


### PR DESCRIPTION
1. Add module of 'tubemq-connectors' for project, it will contains all types of connector for TubeMQ, like Flink, Spark, etc. 
2. Support TubeMQ connector of source for Apache Flink.

Jira link with: https://issues.apache.org/jira/browse/TUBEMQ-197