### PR TITLE
[TUBEMQ-205] Delete duplicate dependency of jetty in tuber-server pom

### DIFF
--- a/tubemq-server/pom.xml
+++ b/tubemq-server/pom.xml
@@ -148,10 +148,6 @@
             <artifactId>velocity</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mortbay.jetty</groupId>
-            <artifactId>jetty</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>


### PR DESCRIPTION
Delete duplicate dependency of jetty in tuber-server pom.

Jira link with: https://issues.apache.org/jira/browse/TUBEMQ-205