### PR TITLE
[TUBEMQ-206] Delete residual files after executed unit tests

### DIFF
--- a/tubemq-server/src/test/java/org/apache/tubemq/server/broker/msgstore/disk/FileSegmentListTest.java
+++ b/tubemq-server/src/test/java/org/apache/tubemq/server/broker/msgstore/disk/FileSegmentListTest.java
@@ -33,13 +33,10 @@ public class FileSegmentListTest {
 
     @Test
     public void getView() {
-        File dir = new File("src/test/resource/data");
-        dir.mkdir();
+        File file = null;
         try {
-            File file =
-                    new File("src/test/resource/data",
-                            DataStoreUtils.nameFromOffset(0L, DataStoreUtils.DATA_FILE_SUFFIX));
-            file.createNewFile();
+            file = File.createTempFile("data",
+                DataStoreUtils.nameFromOffset(0L, DataStoreUtils.DATA_FILE_SUFFIX));
             // create FileSegmentList.
             fileSegmentList = new FileSegmentList();
             fileSegmentList.append(new FileSegment(0, file, SegmentType.DATA));
@@ -55,27 +52,18 @@ public class FileSegmentListTest {
         } catch (IOException e) {
             e.printStackTrace();
         } finally {
-            if (dir.exists()) {
-                dir.delete();
+            if (file != null) {
+                file.deleteOnExit();
             }
         }
     }
 
     @Test
     public void append() {
-        File dir = new File("src/test/resource/data");
-        if (dir.exists()) {
-            File[] files = dir.listFiles();
-            for (File file : files) {
-                file.delete();
-            }
-            dir.delete();
-        }
-        dir.mkdir();
+        File file = null;
         try {
-            File file =
-                    new File("src/test/resource/data",
-                            DataStoreUtils.nameFromOffset(0L, DataStoreUtils.DATA_FILE_SUFFIX));
+            file = File.createTempFile("data",
+                DataStoreUtils.nameFromOffset(0L, DataStoreUtils.DATA_FILE_SUFFIX));
             file.createNewFile();
             // create FileSegmentList.
             fileSegmentList = new FileSegmentList();
@@ -87,9 +75,12 @@ public class FileSegmentListTest {
             fileSegmentList.append(fileSegment);
             Segment[] segmentList = fileSegmentList.getView();
             Assert.assertTrue(segmentList.length == 1);
-            file.delete();
         } catch (IOException e) {
             e.printStackTrace();
+        } finally {
+            if (file != null) {
+                file.deleteOnExit();
+            }
         }
     }
 }

--- a/tubemq-server/src/test/java/org/apache/tubemq/server/broker/msgstore/disk/FileSegmentTest.java
+++ b/tubemq-server/src/test/java/org/apache/tubemq/server/broker/msgstore/disk/FileSegmentTest.java
@@ -31,12 +31,9 @@ public class FileSegmentTest {
     @org.junit.Test
     public void append() {
         long start = 0;
-        File file = new File("src/test/resource/testdata");
-        if (file.exists()) {
-            file.delete();
-        }
+        File file = null;
         try {
-            file.createNewFile();
+            file = File.createTempFile("testdata", null);
             // create FileSegment
             fileSegment = new FileSegment(start, file, true, SegmentType.DATA);
             String data = "abc";
@@ -49,18 +46,18 @@ public class FileSegmentTest {
             e.printStackTrace();
         } finally {
             fileSegment.close();
+            if (file != null) {
+                file.deleteOnExit();
+            }
         }
     }
 
     @org.junit.Test
     public void getViewRef() {
         long start = 0;
-        File file = new File("src/test/resource/testdata");
-        if (file.exists()) {
-            file.delete();
-        }
+        File file = null;
         try {
-            file.createNewFile();
+            file = File.createTempFile("testdata", null);
             // create FileSegment.
             fileSegment = new FileSegment(start, file, true, SegmentType.DATA);
             String data = "abc";
@@ -79,6 +76,9 @@ public class FileSegmentTest {
             e.printStackTrace();
         } finally {
             fileSegment.close();
+            if (file != null) {
+                file.deleteOnExit();
+            }
         }
     }
 }


### PR DESCRIPTION
There are some residual files after executed unit tests by 'tubemq-server' module, create temporary files to avoid this problem.

Jira link with: https://issues.apache.org/jira/browse/TUBEMQ-206