### PR TITLE
[TUBEMQ-203] Upgrade Protocol Buffer component version

### DIFF
--- a/tubemq-core/pom.xml
+++ b/tubemq-core/pom.xml
@@ -31,6 +31,13 @@
     <description>Core functionality for TubeMQ</description>
 
     <build>
+        <extensions>
+            <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>1.5.0.Final</version>
+            </extension>
+        </extensions>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -53,21 +60,28 @@
                 </configuration>
             </plugin>
             <plugin>
-                <groupId>com.github.igor-petruk.protobuf</groupId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.xolstice.maven.plugins</groupId>
                 <artifactId>protobuf-maven-plugin</artifactId>
-                <version>0.6.3</version>
+                <version>0.6.1</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <protoSourceRoot>${project.basedir}/src/main/protobuf</protoSourceRoot>
+                    <outputDirectory>${project.build.directory}/generated-sources/java</outputDirectory>
+                    <protocArtifact>
+                        com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}
+                    </protocArtifact>
+                </configuration>
                 <executions>
                     <execution>
-                        <phase>generate-sources</phase>
                         <goals>
-                            <goal>run</goal>
+                            <goal>compile</goal>
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Remove the steps that need to explicitly configure protocol buffer on the local machine, and directly use Maven plugin to complete, simplifying the process of contributor's configuration of Pb environment