### PR TITLE
[TUBEMQ-224] Fixed: Unnecessary conversion to string inspection for server module

### DIFF
--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/web/BrokerAdminServlet.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/web/BrokerAdminServlet.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -281,7 +281,7 @@ public class BrokerAdminServlet extends HttpServlet {
         Set<String> batchTopicNames = new HashSet<>();
         String inputTopicName = req.getParameter("topicName");
         if (TStringUtils.isNotBlank(inputTopicName)) {
-            inputTopicName = String.valueOf(inputTopicName).trim();
+            inputTopicName = inputTopicName.trim();
             String[] strTopicNames =
                     inputTopicName.split(TokenConstants.ARRAY_SEP);
             for (int i = 0; i < strTopicNames.length; i++) {

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/web/handler/WebAdminGroupCtrlHandler.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/web/handler/WebAdminGroupCtrlHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -543,7 +543,7 @@ public class WebAdminGroupCtrlHandler {
             Set<String> batchOpConsumerIds = new HashSet<>();
             String inputConsumerId = req.getParameter("consumerId");
             if (TStringUtils.isNotBlank(inputConsumerId)) {
-                inputConsumerId = String.valueOf(inputConsumerId).trim();
+                inputConsumerId = inputConsumerId.trim();
                 String[] strInputConsumerIds =
                         inputConsumerId.split(TokenConstants.ARRAY_SEP);
                 for (int i = 0; i < strInputConsumerIds.length; i++) {

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/web/handler/WebBrokerDefConfHandler.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/web/handler/WebBrokerDefConfHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -1496,8 +1496,8 @@ public class WebBrokerDefConfHandler {
                         .append(",\"memCacheFlushIntvl\":").append(recordMemCacheFlushIntvl)
                         .append(",\"deleteWhen\":\"").append(entity.getDftDeleteWhen())
                         .append("\",\"deletePolicy\":\"").append(entity.getDftDeletePolicy())
-                        .append("\",\"acceptPublish\":").append(String.valueOf(entity.isAcceptPublish()))
-                        .append(",\"acceptSubscribe\":").append(String.valueOf(entity.isAcceptSubscribe()))
+                        .append("\",\"acceptPublish\":").append(entity.isAcceptPublish())
+                        .append(",\"acceptSubscribe\":").append(entity.isAcceptSubscribe())
                         .append(",\"createUser\":\"").append(entity.getRecordCreateUser())
                         .append("\",\"createDate\":\"").append(formatter.format(entity.getRecordCreateDate()))
                         .append("\",\"modifyUser\":\"").append(entity.getRecordModifyUser())
@@ -1613,8 +1613,8 @@ public class WebBrokerDefConfHandler {
                             .append(",\"memCacheFlushIntvl\":").append(topicEntity.getMemCacheFlushIntvl())
                             .append(",\"deleteWhen\":\"").append(topicEntity.getDeleteWhen())
                             .append("\",\"deletePolicy\":\"").append(topicEntity.getDeletePolicy())
-                            .append("\",\"acceptPublish\":").append(String.valueOf(topicEntity.getAcceptPublish()))
-                            .append(",\"acceptSubscribe\":").append(String.valueOf(topicEntity.getAcceptSubscribe()))
+                            .append("\",\"acceptPublish\":").append(topicEntity.getAcceptPublish())
+                            .append(",\"acceptSubscribe\":").append(topicEntity.getAcceptSubscribe())
                             .append(",\"createUser\":\"").append(topicEntity.getCreateUser())
                             .append("\",\"createDate\":\"").append(formatter.format(topicEntity.getCreateDate()))
                             .append("\",\"modifyUser\":\"").append(topicEntity.getModifyUser())

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/web/handler/WebBrokerTopicConfHandler.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/web/handler/WebBrokerTopicConfHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one or more
  * contributor license agreements.  See the NOTICE file distributed with
  * this work for additional information regarding copyright ownership.
@@ -555,8 +555,8 @@ public class WebBrokerTopicConfHandler {
                             .append(",\"unFlushDataHold\":").append(entity.getUnflushDataHold())
                             .append(",\"deleteWhen\":\"").append(entity.getDeleteWhen())
                             .append("\",\"deletePolicy\":\"").append(entity.getDeletePolicy())
-                            .append("\",\"acceptPublish\":").append(String.valueOf(entity.getAcceptPublish()))
-                            .append(",\"acceptSubscribe\":").append(String.valueOf(entity.getAcceptSubscribe()))
+                            .append("\",\"acceptPublish\":").append(entity.getAcceptPublish())
+                            .append(",\"acceptSubscribe\":").append(entity.getAcceptSubscribe())
                             .append(",\"numTopicStores\":").append(entity.getNumTopicStores())
                             .append(",\"memCacheMsgSizeInMB\":").append(entity.getMemCacheMsgSizeInMB())
                             .append(",\"memCacheFlushIntvl\":").append(entity.getMemCacheFlushIntvl())


### PR DESCRIPTION
Fixed unnecessary method calls such as String.valueOf ()
For exmple:
```
String.valueOf(inputTopicName).trim();

change to

inputTopicName.trim();
```
```
String.valueOf(inputConsumerId).trim();

change to 

inputConsumerId.trim();
```
etc..