### PR TITLE
[TUBEMQ-124] Structured index storage

### DIFF
--- a/conf/broker.ini
+++ b/conf/broker.ini
@@ -38,7 +38,8 @@ transferSize= 524288
 loadMessageStoresInParallel=true
 ; timeout of consumer heartbeat, optional; default is 30s
 consumerRegTimeoutMs=35000
-
+; enable MessageFileStore index, 0=disable, +Integer=<estimated clients amount scale>
+_mfsIndexScale=0
 
 [zookeeper]
 ; root path of TubeMQ znodes on ZK

--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava</artifactId>
-                <version>13.0</version>
+                <version>23.0</version>
             </dependency>
             <dependency>
                 <groupId>javax.servlet</groupId>

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/BrokerConfig.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/BrokerConfig.java
@@ -38,6 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 public class BrokerConfig extends AbstractFileConfig {
     static final long serialVersionUID = -1L;
+    public static final int MaxIndexSegmentElements = 700000;
     private static final Logger logger = LoggerFactory.getLogger(BrokerConfig.class);
     // broker id
     private int brokerId = 0;
@@ -69,7 +70,7 @@ public class BrokerConfig extends AbstractFileConfig {
     // max data segment size
     private int maxSegmentSize = 1024 * 1024 * 1024;
     // max index segment size
-    private int maxIndexSegmentSize = 700000 * DataStoreUtils.STORE_INDEX_HEAD_LEN;
+    private int maxIndexSegmentSize = MaxIndexSegmentElements * DataStoreUtils.STORE_INDEX_HEAD_LEN;
     // transfer size
     private int transferSize = 512 * 1024;
     // transfer index count

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/BrokerConfig.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/BrokerConfig.java
@@ -114,6 +114,8 @@ public class BrokerConfig extends AbstractFileConfig {
     private String visitName = "";
     private String visitPassword = "";
     private long authValidTimeStampPeriodMs = TBaseConstants.CFG_DEFAULT_AUTH_TIMESTAMP_VALID_INTERVAL;
+    // MessageFileStore negative prediction index, 0=disabled, +Integer=<estimated clients amount scale>
+    private int mfsIndexScale = 0;
 
     public BrokerConfig() {
         super();
@@ -334,6 +336,7 @@ public class BrokerConfig extends AbstractFileConfig {
             this.visitName = brokerSect.get("visitName").trim();
             this.visitPassword = brokerSect.get("visitPassword").trim();
         }
+        this.mfsIndexScale = this.getInt(brokerSect, "_mfsIndexScale", 0);
     }
 
     public long getLogClearupDurationMs() {
@@ -454,5 +457,8 @@ public class BrokerConfig extends AbstractFileConfig {
         return masterAddressList;
     }
 
+    public int getMfsIndexScale() {
+        return mfsIndexScale;
+    }
 
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/disk/MsgFileStore.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/disk/MsgFileStore.java
@@ -635,7 +635,9 @@ public class MsgFileStore implements Closeable {
     }
 
     private void rebuildOverviewIndex(List<Segment> accum) throws IOException {
-        if (this.tubeConfig.getMfsIndexScale() <= 0) return;
+        if (this.tubeConfig.getMfsIndexScale() <= 0) {
+            return;
+        }
 
         overviewSegments = new ConcurrentLinkedDeque<BloomFilter<Integer>>();
         try {

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/disk/SegmentList.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/disk/SegmentList.java
@@ -30,6 +30,8 @@ public interface SegmentList {
 
     Segment findSegment(final long offset);
 
+    int findSegmentIndex(long offset);
+
     Segment[] getView();
 
     long getSizeInBytes();
@@ -38,7 +40,7 @@ public interface SegmentList {
 
     boolean checkExpiredSegments(final long checkTimestamp, final long fileValidTimeMs);
 
-    void delExpiredSegments(final StringBuilder sb);
+    int delExpiredSegments(final StringBuilder sb);
 
     void flushLast(boolean force) throws IOException;
 
@@ -51,5 +53,7 @@ public interface SegmentList {
     void delete(final Segment segment);
 
     Segment getRecordSeg(final long offset) throws IOException;
+
+    int getSegmentIndex(long offset) throws IOException;
 
 }


### PR DESCRIPTION
**Initial Prototype** for demonstration only
Further details needs to be discussed. Currently it should be incomplete, and it *will* be some time.

Here the major issue directly from initial plan in TUBEMQ-124, I think, contains (but not limited to):
1. Bloom Filter, as a probability prediction set, does **not** support a **remove** operation, so we have to choose an *appropriate* time to rebuild it after a long run with massive topics in and out, which is such an expensive thing just like the GC STP (stop-the-world);
2. Fine-grained control might be introduced to scatter the impact while exploit the negative-prediction efficiency, like we could do something like Java 8 revised ConcurrentHashMap, we could setup Bloom Filter on Segment (even available for memory prediction), and apply something like URA (unbalanced resource allocation) to better concentrate messages of the same topic into the same segment.
Please review the prototype about the overall architecture of how Bloom Filter (my opinion) could behave, and let's discuss something in details about above factors, if any or more.

Details: [TUBEMQ-124](https://issues.apache.org/jira/projects/TUBEMQ/issues/TUBEMQ-124)
*The same would be synchronized to original issue comments*