### PR TITLE
[TUBEMQ-232] TubeBroker#register2Master, reconnect and wait

### DIFF
--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/TubeBroker.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/TubeBroker.java
@@ -430,6 +430,7 @@ public class TubeBroker implements Stoppable {
                 if (remainingRetry == 0) {
                     throw new StartupException("Register to master failed!", e);
                 }
+                ThreadUtils.sleep(200);
             }
         }
     }


### PR DESCRIPTION
If the broker fails to register with the master, a total of 5 reconnections will be attempted. But I think we should pause the thread for a period of time every time the connection fails to be reconnected
```
for (int i; i < reconnectionTimes; i++) {
    try {
        tryConnect();
    } catch (Throwable e) {
        try {
            TimeUnit.MILLISECONDS.sleep(200);
        } catch (InterruptedException ignored) {
            //ignore interrupted
        }
    }
}
```