### PR TITLE
[TUBEMQ-126] Increase the unflushed data bytes control

### DIFF
--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/metadata/BrokerDefMetadata.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/metadata/BrokerDefMetadata.java
@@ -32,7 +32,7 @@ public class BrokerDefMetadata {
     private int numPartitions = 1;
     // data will be flushed to disk when unflushed message count exceed this.
     private int unflushThreshold = 1000;
-    @Deprecated
+    // data will be flushed to disk when unflushed data size reaches the threshold.
     private int unflushDataHold = 10000;
     // data will be flushed to disk when elapse unflushInterval milliseconds since last flush operation.
     private int unflushInterval = 10000;

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/metadata/BrokerDefMetadata.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/metadata/BrokerDefMetadata.java
@@ -32,8 +32,8 @@ public class BrokerDefMetadata {
     private int numPartitions = 1;
     // data will be flushed to disk when unflushed message count exceed this.
     private int unflushThreshold = 1000;
-    // data will be flushed to disk when unflushed data size reaches the threshold.
-    private int unflushDataHold = 10000;
+    // data will be flushed to disk when unflushed data size reaches the threshold, 0=disabled.
+    private int unflushDataHold = 0;
     // data will be flushed to disk when elapse unflushInterval milliseconds since last flush operation.
     private int unflushInterval = 10000;
     // enable produce data to topic.

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/metadata/TopicMetadata.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/metadata/TopicMetadata.java
@@ -37,8 +37,8 @@ public class TopicMetadata {
     private int unflushThreshold = 1000;
     // data will be flushed to disk when unflushed message count exceed this.
     private int unflushInterval = 10000;
-    // data will be flushed to disk when unflushed data size reach this threshold.
-    private int unflushDataHold = 10000;
+    // data will be flushed to disk when unflushed data size reach this threshold, 0=disabled.
+    private int unflushDataHold = 0;
     // enable produce data to topic.
     private boolean acceptPublish = true;
     // enable consume data from topic.

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/metadata/TopicMetadata.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/metadata/TopicMetadata.java
@@ -37,7 +37,7 @@ public class TopicMetadata {
     private int unflushThreshold = 1000;
     // data will be flushed to disk when unflushed message count exceed this.
     private int unflushInterval = 10000;
-    @Deprecated
+    // data will be flushed to disk when unflushed data size reach this threshold.
     private int unflushDataHold = 10000;
     // enable produce data to topic.
     private boolean acceptPublish = true;
@@ -137,8 +137,8 @@ public class TopicMetadata {
     }
 
     private TopicMetadata(String topic, int unflushThreshold,
-                          int unflushInterval, String dataPath,
-                          String deleteWhen, String deletePolicy,
+                          int unflushInterval, int unflushDataHold,
+                          String dataPath, String deleteWhen, String deletePolicy,
                           int numPartitions, boolean acceptPublish,
                           boolean acceptSubscribe, int statusId,
                           int numTopicStores, int memCacheMsgSize,
@@ -146,6 +146,7 @@ public class TopicMetadata {
         this.topic = topic;
         this.unflushThreshold = unflushThreshold;
         this.unflushInterval = unflushInterval;
+        this.unflushDataHold = unflushDataHold;
         this.dataPath = dataPath;
         this.deleteWhen = deleteWhen;
         this.deletePolicy = deletePolicy;
@@ -162,8 +163,8 @@ public class TopicMetadata {
     @Override
     public TopicMetadata clone() {
         return new TopicMetadata(this.topic, this.unflushThreshold,
-                this.unflushInterval, this.dataPath,
-                this.deleteWhen, this.deletePolicy,
+                this.unflushInterval, this.unflushDataHold,
+                this.dataPath, this.deleteWhen, this.deletePolicy,
                 this.numPartitions, this.acceptPublish,
                 this.acceptSubscribe, this.statusId,
                 this.numTopicStores, this.memCacheMsgSize,
@@ -218,6 +219,14 @@ public class TopicMetadata {
         this.unflushThreshold = unflushThreshold;
     }
 
+    public int getUnflushDataHold() {
+        return this.unflushDataHold;
+    }
+
+    public void setUnflushDataHold(final int unflushDataHold) {
+        this.unflushDataHold = unflushDataHold;
+    }
+
     public int getUnflushInterval() {
         return this.unflushInterval;
     }
@@ -264,6 +273,7 @@ public class TopicMetadata {
         result = prime * result + (this.topic == null ? 0 : this.topic.hashCode());
         result = prime * result + this.unflushInterval;
         result = prime * result + this.unflushThreshold;
+        result = prime * result + this.unflushDataHold;
         result = prime * result + this.statusId;
         result = prime * result + this.memCacheMsgSize;
         result = prime * result + this.memCacheMsgCnt;
@@ -327,6 +337,9 @@ public class TopicMetadata {
         if (this.unflushThreshold != other.unflushThreshold) {
             return false;
         }
+        if (this.unflushDataHold != other.unflushDataHold) {
+            return false;
+        }
         if (this.statusId != other.statusId) {
             return false;
         }
@@ -356,6 +369,7 @@ public class TopicMetadata {
         return (this.numPartitions == other.numPartitions
                 && this.unflushInterval == other.unflushInterval
                 && this.unflushThreshold == other.unflushThreshold
+                && this.unflushDataHold == other.unflushDataHold
                 && this.memCacheMsgSize == other.memCacheMsgSize
                 && this.memCacheMsgCnt == other.memCacheMsgCnt
                 && this.memCacheFlushIntvl == other.memCacheFlushIntvl
@@ -367,6 +381,7 @@ public class TopicMetadata {
         return new StringBuilder(512).append("TopicMetadata [topic=").append(this.topic)
                 .append(", unflushThreshold=").append(this.unflushThreshold)
                 .append(", unflushInterval=").append(this.unflushInterval)
+                .append(", unflushDataHold=").append(this.unflushDataHold)
                 .append(", dataPath=").append(this.dataPath)
                 .append(", deleteWhen=").append(this.deleteWhen)
                 .append(", deletePolicy=").append(this.deletePolicy)

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/MessageStore.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/MessageStore.java
@@ -76,6 +76,7 @@ public class MessageStore implements Closeable {
     private volatile int partitionNum;
     private AtomicInteger unflushInterval = new AtomicInteger(0);
     private AtomicInteger unflushThreshold = new AtomicInteger(0);
+    private AtomicInteger unflushDataHold = new AtomicInteger(0);
     private volatile int writeCacheMaxSize;
     private volatile int writeCacheMaxCnt;
     private volatile int writeCacheFlushIntvl;
@@ -120,6 +121,7 @@ public class MessageStore implements Closeable {
         this.unflushInterval.set(topicMetadata.getUnflushInterval());
         this.maxFileValidDurMs.set(parseDeletePolicy(topicMetadata.getDeletePolicy()));
         this.unflushThreshold.set(topicMetadata.getUnflushThreshold());
+        this.unflushDataHold.set(topicMetadata.getUnflushDataHold());
         this.writeCacheMaxCnt = topicMetadata.getMemCacheMsgCnt();
         this.writeCacheMaxSize = topicMetadata.getMemCacheMsgSize();
         this.writeCacheFlushIntvl = topicMetadata.getMemCacheFlushIntvl();
@@ -142,10 +144,6 @@ public class MessageStore implements Closeable {
         this.msgMemStoreBeingFlush.resetStartPos(
                 this.msgFileStore.getDataMaxOffset(), this.msgFileStore.getIndexMaxOffset());
         this.lastMemFlushTime.set(System.currentTimeMillis());
-    }
-
-    public TopicMetadata getTopicMetadata() {
-        return topicMetadata;
     }
 
     /***
@@ -387,6 +385,7 @@ public class MessageStore implements Closeable {
         partitionNum = topicMetadata.getNumPartitions();
         unflushInterval.set(topicMetadata.getUnflushInterval());
         unflushThreshold.set(topicMetadata.getUnflushThreshold());
+        unflushDataHold.set(topicMetadata.getUnflushDataHold());
         maxFileValidDurMs.set(parseDeletePolicy(topicMetadata.getDeletePolicy()));
         int tmpIndexReadCnt = tubeConfig.getIndexTransCount() * partitionNum;
         memMaxIndexReadCnt.set(tmpIndexReadCnt <= 6000
@@ -489,6 +488,10 @@ public class MessageStore implements Closeable {
 
     public int getUnflushThreshold() {
         return this.unflushThreshold.get();
+    }
+
+    public int getUnflushDataHold() {
+        return this.unflushDataHold.get();
     }
 
     public long getIndexMaxOffset() {

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/MessageStore.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/MessageStore.java
@@ -144,6 +144,10 @@ public class MessageStore implements Closeable {
         this.lastMemFlushTime.set(System.currentTimeMillis());
     }
 
+    public TopicMetadata getTopicMetadata() {
+        return topicMetadata;
+    }
+
     /***
      * Get message from message store. Support the given offset, filter.
      *

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/disk/MsgFileStore.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/disk/MsgFileStore.java
@@ -169,7 +169,7 @@ public class MsgFileStore implements Closeable {
             }
             // check whether need to flush to disk.
             long currTime = System.currentTimeMillis();
-            int unflushDataHold = this.messageStore.getTopicMetadata().getUnflushDataHold();
+            int unflushDataHold = messageStore.getUnflushDataHold();
             if ((isMsgCntFlushed = this.curUnflushed.addAndGet(msgCnt) >= messageStore.getUnflushThreshold())
                 || (isMsgTimeFushed = currTime - this.lastFlushTime.get() >= messageStore.getUnflushInterval())
                 || (unflushDataHold > 0 && curUnflushSize.get() >= unflushDataHold)

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/disk/MsgFileStore.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/msgstore/disk/MsgFileStore.java
@@ -169,8 +169,10 @@ public class MsgFileStore implements Closeable {
             }
             // check whether need to flush to disk.
             long currTime = System.currentTimeMillis();
+            int unflushDataHold = this.messageStore.getTopicMetadata().getUnflushDataHold();
             if ((isMsgCntFlushed = this.curUnflushed.addAndGet(msgCnt) >= messageStore.getUnflushThreshold())
                 || (isMsgTimeFushed = currTime - this.lastFlushTime.get() >= messageStore.getUnflushInterval())
+                || (unflushDataHold > 0 && curUnflushSize.get() >= unflushDataHold)
                 || isDataFlushed || isIndexFlushed) {
                 boolean forceMetadata = (isDataFlushed || isIndexFlushed
                     || (currTime - this.lastMetaFlushTime.get() > MAX_META_REFRESH_DUR));


### PR DESCRIPTION
Implement the unflushSize as a factor to trigger data flush, and the changes consist of the following 3 parts:

**MsgFileStore**: Make use of curUnflushSize and unflushDataHold settings to trigger;
**Metadata**: Reuse unflushDataHold to store the flush strategy;

Details: [TUBE-126](https://issues.apache.org/jira/browse/TUBEMQ-126)