### PR TITLE
[TUBEMQ-265] Unexpected broker disappearance in broker list after updating default broker metadata

### DIFF
--- a/bin/env.cmd
+++ b/bin/env.cmd
@@ -28,4 +28,4 @@ set JAVA="%JAVA_HOME%\bin\java"
 
 REM One may add extra Java runtime flags in addition to each role: Master or Broker
 set MASTER_JVM_OPTS=-Xmx1g -Xms256m -server
-set BROKER_JVM_OPTS=-Xmx1g -Xms512g -server
+set BROKER_JVM_OPTS=-Xmx1g -Xms512m -server

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/web/handler/WebBrokerDefConfHandler.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/web/handler/WebBrokerDefConfHandler.java
@@ -1218,6 +1218,7 @@ public class WebBrokerDefConfHandler {
         StringBuilder strBuffer = new StringBuilder(512);
         try {
             BdbBrokerConfEntity brokerConfEntity = new BdbBrokerConfEntity();
+            brokerConfEntity.setDftUnFlushDataHold(TBaseConstants.META_VALUE_UNDEFINED);
             boolean withDetail =
                 WebParameterUtils.validBooleanDataParameter("withDetail",
                     req.getParameter("withDetail"), false, false);
@@ -1402,6 +1403,7 @@ public class WebBrokerDefConfHandler {
     public StringBuilder adminQueryBrokerDefConfEntityInfo(HttpServletRequest req) throws Exception {
         StringBuilder strBuffer = new StringBuilder(512);
         BdbBrokerConfEntity brokerConfEntity = new BdbBrokerConfEntity();
+        brokerConfEntity.setDftUnFlushDataHold(TBaseConstants.META_VALUE_UNDEFINED);
         try {
             brokerConfEntity
                     .setRecordCreateUser(WebParameterUtils.validStringParameter("createUser",

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/web/handler/WebBrokerTopicConfHandler.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/web/handler/WebBrokerTopicConfHandler.java
@@ -1051,6 +1051,7 @@ public class WebBrokerTopicConfHandler {
             webTopicEntity.setMemCacheMsgSizeInMB(TBaseConstants.META_VALUE_UNDEFINED);
             webTopicEntity.setMemCacheMsgCntInK(TBaseConstants.META_VALUE_UNDEFINED);
             webTopicEntity.setMemCacheFlushIntvl(TBaseConstants.META_VALUE_UNDEFINED);
+            webTopicEntity.setUnflushDataHold(TBaseConstants.META_VALUE_UNDEFINED);
             Map<Integer, BdbBrokerConfEntity> totalBrokers =
                     brokerConfManager.getBrokerConfStoreMap();
             Map<Integer, BrokerSyncStatusInfo> brokerSyncStatusInfoMap =


### PR DESCRIPTION
As in bug description, it would fail the data validation as we have reused a parameter which was deprecated, and has modified the original definition in BDB, so it requires to be set as UNDEFINED or it would be treated as not properly initialized.
By the way, fix a tiny typo that the min heap size would never be 512g (too big!).