### PR TITLE
[TUBEMQ-308] Upgrade Jetty 6 (mortbay) => Jetty 9 (eclipse)

### DIFF
--- a/tubemq-server/pom.xml
+++ b/tubemq-server/pom.xml
@@ -185,8 +185,14 @@
             <artifactId>commons-cli</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.mortbay.jetty</groupId>
-            <artifactId>jetty</artifactId>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-server</artifactId>
+            <version>9.4.31.v20200723</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty</groupId>
+            <artifactId>jetty-servlet</artifactId>
+            <version>9.4.31.v20200723</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/broker/web/WebServer.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/broker/web/WebServer.java
@@ -20,7 +20,8 @@ package org.apache.tubemq.server.broker.web;
 import static com.google.common.base.Preconditions.checkArgument;
 import org.apache.tubemq.server.Server;
 import org.apache.tubemq.server.broker.TubeBroker;
-import org.mortbay.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.servlet.ServletContextHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 
 /***
  * Broker's http server.
@@ -29,7 +30,7 @@ public class WebServer implements Server {
 
     private String hostname = "0.0.0.0";
     private int port = 8080;
-    private org.mortbay.jetty.Server srv;
+    private org.eclipse.jetty.server.Server srv;
     private TubeBroker broker;
 
     public WebServer(String hostname, int port, TubeBroker broker) {
@@ -40,9 +41,9 @@ public class WebServer implements Server {
 
     @Override
     public void start() throws Exception {
-        srv = new org.mortbay.jetty.Server(this.port);
-        org.mortbay.jetty.servlet.Context servletContext =
-                new org.mortbay.jetty.servlet.Context(srv, "/", org.mortbay.jetty.servlet.Context.SESSIONS);
+        srv = new org.eclipse.jetty.server.Server(this.port);
+        ServletContextHandler servletContext =
+                new ServletContextHandler(srv, "/", ServletContextHandler.SESSIONS);
 
         servletContext.addServlet(new ServletHolder(new BrokerAdminServlet(broker)), "/*");
         srv.start();


### PR DESCRIPTION
As mortbay version of Jetty 6 is old enough, this PR upgrade it to the latest eclipse version of Jetty 9, so as to keep in sync with the latest fixes and improvements.
Also it's the pre-step of adding support about POST request, as there has been no document for now to develop on Jetty 6 (a thing about 10+ years ago).