### PR TITLE
[TUBEMQ-359] TubeMQ consume speed dropped to 0 in some partitions, it is a very serious bug

### DIFF
--- a/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/BaseMessageConsumer.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/BaseMessageConsumer.java
@@ -1486,11 +1486,8 @@ public class BaseMessageConsumer implements MessageConsumer {
         public void run() {
             StringBuilder strBuffer = new StringBuilder(256);
             try {
-                if (isPullConsume) {
-                    // For pull consume, do timeout check on partitions pulled without confirm
-                    rmtDataCache.resumeTimeoutConsumePartitions(
-                            consumerConfig.getPullProtectConfirmTimeoutMs());
-                }
+                rmtDataCache.resumeTimeoutConsumePartitions(isPullConsume,
+                        consumerConfig.getPullProtectConfirmTimeoutMs());
                 // Fetch the rebalance result, construct message adn return it.
                 ConsumerEvent event = rebalanceResults.poll();
                 List<SubscribeInfo> subInfoList = null;

--- a/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/RmtDataCache.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/RmtDataCache.java
@@ -681,18 +681,21 @@ public class RmtDataCache implements Closeable {
         return this.brokerPartitionConMap.get(brokerInfo);
     }
 
-    public void resumeTimeoutConsumePartitions(long allowedPeriodTimes) {
-        if (!partitionUsedMap.isEmpty()) {
-            List<String> partKeys = new ArrayList<>(partitionUsedMap.keySet());
-            for (String keyId : partKeys) {
-                Long oldTime = partitionUsedMap.get(keyId);
-                if (oldTime != null && System.currentTimeMillis() - oldTime > allowedPeriodTimes) {
-                    oldTime = partitionUsedMap.remove(keyId);
-                    if (oldTime != null) {
-                        PartitionExt partitionExt = partitionMap.get(keyId);
-                        if (partitionExt != null) {
-                            partitionExt.setLastPackConsumed(false);
-                            releaseIdlePartition(keyId);
+    public void resumeTimeoutConsumePartitions(boolean isPullConsume, long allowedPeriodTimes) {
+        if (isPullConsume) {
+            // For pull consume, do timeout check on partitions pulled without confirm
+            if (!partitionUsedMap.isEmpty()) {
+                List<String> partKeys = new ArrayList<>(partitionUsedMap.keySet());
+                for (String keyId : partKeys) {
+                    Long oldTime = partitionUsedMap.get(keyId);
+                    if (oldTime != null && System.currentTimeMillis() - oldTime > allowedPeriodTimes) {
+                        oldTime = partitionUsedMap.remove(keyId);
+                        if (oldTime != null) {
+                            PartitionExt partitionExt = partitionMap.get(keyId);
+                            if (partitionExt != null) {
+                                partitionExt.setLastPackConsumed(false);
+                                releaseIdlePartition(keyId);
+                            }
                         }
                     }
                 }

--- a/tubemq-client/src/test/java/org/apache/tubemq/client/consumer/RmtDataCacheTest.java
+++ b/tubemq-client/src/test/java/org/apache/tubemq/client/consumer/RmtDataCacheTest.java
@@ -65,7 +65,7 @@ public class RmtDataCacheTest {
         assertEquals(1, cache.getBrokerPartitionList(brokerInfo).size());
         assertEquals(1, cache.getCurPartitionInfoMap().size());
         assertEquals(1, cache.getAllPartitionListWithStatus().size());
-        cache.resumeTimeoutConsumePartitions(1000);
+        cache.resumeTimeoutConsumePartitions(true, 1000);
         Map<BrokerInfo, List<Partition>> infoMap = new HashMap<>();
         cache.removeAndGetPartition(infoMap, new ArrayList<String>(), 1000, true);
         cache.getSubscribeInfoList("test", "test");


### PR DESCRIPTION
Analyzing the code, the timer event loss has never occurred before, it is suspected to be related to the running platform environment. I add a timeout detection mechanism to the Push consumption mode, which trigger a timeout events to the partitions that have expired but have not triggered , to avoid partition idleness .
![image](https://user-images.githubusercontent.com/14038849/94138880-4cf62b80-fe58-11ea-8c7f-7b04f88bde16.png)
