### PR TITLE
[TUBEMQ-380] fix static const variable definition

### DIFF
--- a/tubemq-client-twins/tubemq-client-cpp/src/client_connection.cc
+++ b/tubemq-client-twins/tubemq-client-cpp/src/client_connection.cc
@@ -21,6 +21,8 @@
 
 using namespace tubemq;
 
+const uint32_t ClientConnection::kConnnectMaxTimeMs;
+
 void ClientConnection::AsyncWrite(RequestContextPtr& req) {
   auto self = shared_from_this();
   executor_->Post([self, this, req]() {

--- a/tubemq-client-twins/tubemq-client-cpp/src/client_service.cc
+++ b/tubemq-client-twins/tubemq-client-cpp/src/client_service.cc
@@ -30,6 +30,8 @@ namespace tubemq {
 using std::lock_guard;
 using std::stringstream;
 
+const uint32_t ConnectionPool::kRegularTimerSecond;
+
 BaseClient::BaseClient(bool is_producer) {
   is_producer_ = is_producer;
   client_index_ = tb_config::kInvalidValue;


### PR DESCRIPTION
Add static const variable definition to fix link error reported at https://issues.apache.org/jira/browse/TUBEMQ-380