### PR TITLE
[TUBEMQ-441]An error occurred when using the Tubemq class to create a sink table

### DIFF
--- a/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/Tubemq.java
+++ b/tubemq-connectors/tubemq-connector-flink/src/main/java/org/apache/flink/connectors/tubemq/Tubemq.java
@@ -41,6 +41,9 @@ import org.apache.flink.table.descriptors.DescriptorProperties;
 public class Tubemq extends ConnectorDescriptor {
 
     @Nullable
+    private boolean consumerRole = true;
+
+    @Nullable
     private String topic;
 
     @Nullable
@@ -70,6 +73,16 @@ public class Tubemq extends ConnectorDescriptor {
         checkNotNull(topic);
 
         this.topic = topic;
+        return this;
+    }
+
+    /**
+     * Sets the client role to be used.
+     *
+     * @param isConsumer The client role if consumer.
+     */
+    public Tubemq asConsumer(boolean isConsumer) {
+        this.consumerRole = isConsumer;
         return this;
     }
 
@@ -133,13 +146,14 @@ public class Tubemq extends ConnectorDescriptor {
         if (master != null) {
             descriptorProperties.putString(CONNECTOR_MASTER, master);
         }
+        if (consumerRole) {
+            if (group != null) {
+                descriptorProperties.putString(CONNECTOR_GROUP, group);
+            }
 
-        if (group != null) {
-            descriptorProperties.putString(CONNECTOR_GROUP, group);
-        }
-
-        if (tids != null) {
-            descriptorProperties.putString(CONNECTOR_TIDS, tids);
+            if (tids != null) {
+                descriptorProperties.putString(CONNECTOR_TIDS, tids);
+            }
         }
 
         descriptorProperties.putPropertiesWithPrefix(CONNECTOR_PROPERTIES, properties);


### PR DESCRIPTION
The reason for this problem is that the Tubemq class is shared in the source and sink, but the required parameters required by the source and sink are inconsistent, the Tubemq.toConnectorProperties() does not check whether the corresponding required parameters are met according to different ways of use.

The problem is solved by adding the consumerRole attribute (the default true, consumer role) and the role setting API asConsumer (boolean isConsumer) in the Tubemq class