### PR TITLE
[TUBEMQ-442]Modifying the jvm parameters when the broker starts does not take effect

### DIFF
--- a/bin/env.sh
+++ b/bin/env.sh
@@ -35,7 +35,7 @@ if [ -z "$MASTER_JVM_SIZE" ]; then
 fi
 MASTER_JVM_ARGS="$MASTER_JVM_SIZE -server -Dtubemq.home=$tubemq_home -cp $CLASSPATH "
 #Broker jvm args
-if [ -z "$MASTER_JVM_SIZE" ]; then
+if [ -z "$BROKER_JVM_SIZE" ]; then
   BROKER_JVM_SIZE="-Xmx16g -Xms8g"
 fi
 BROKER_JVM_ARGS="$BROKER_JVM_SIZE -server -Dtubemq.home=$tubemq_home -cp $CLASSPATH "


### PR DESCRIPTION
This problem is a clerical error. TubeMQ is used in very large-scale scenarios, Master and Broker are rarely deployed in one machine, even if they are deployed in one, there is no performance problem, so this problem has not been found.