### PR TITLE
[TUBEMQ-445]Adjust the status check default sleep interval of pullConsumeReadyChkSliceMs

### DIFF
--- a/tubemq-client/src/main/java/org/apache/tubemq/client/common/TClientConstants.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/common/TClientConstants.java
@@ -25,7 +25,7 @@ public class TClientConstants {
     public static final long CFG_DEFAULT_REGFAIL_WAIT_PERIOD_MS = 1000;
     public static final long CFG_DEFAULT_MSG_NOTFOUND_WAIT_PERIOD_MS = 400L;
     public static final long CFG_DEFAULT_CONSUME_READ_WAIT_PERIOD_MS = 90000L;
-    public static final long CFG_DEFAULT_CONSUME_READ_CHECK_SLICE_MS = 300L;
+    public static final long CFG_DEFAULT_CONSUME_READ_CHECK_SLICE_MS = 50L;
     public static final long CFG_DEFAULT_PUSH_LISTENER_WAIT_PERIOD_MS = 3000L;
     public static final long CFG_DEFAULT_PULL_REB_CONFIRM_WAIT_PERIOD_MS = 3000L;
     public static final long CFG_DEFAULT_PULL_PROTECT_CONFIRM_WAIT_PERIOD_MS = 60000L;

--- a/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/SimplePullMessageConsumer.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/consumer/SimplePullMessageConsumer.java
@@ -147,7 +147,9 @@ public class SimplePullMessageConsumer implements PullMessageConsumer {
                     baseConsumer.getConsumerConfig().getPullConsumeReadyWaitPeriodMs())) {
                 return new ConsumerResult(selectResult.getErrCode(), selectResult.getErrMsg());
             }
-            ThreadUtils.sleep(baseConsumer.getConsumerConfig().getPullConsumeReadyChkSliceMs());
+            if (baseConsumer.getConsumerConfig().getPullConsumeReadyChkSliceMs() > 10) {
+                ThreadUtils.sleep(baseConsumer.getConsumerConfig().getPullConsumeReadyChkSliceMs());
+            }
         }
         StringBuilder sBuilder = new StringBuilder(512);
         // Check the data cache first


### PR DESCRIPTION
Since the available status of the partition is also controlled by the server, if the detection sleep interval is too long, the partition consumption delay response will not be sensitive enough, so adjust the value to a smaller value.