### PR TITLE
[TUBEMQ-446]Small bugs fix that do not affect the main logics

### DIFF
--- a/tubemq-core/src/main/java/org/apache/tubemq/corebase/utils/AddressUtils.java
+++ b/tubemq-core/src/main/java/org/apache/tubemq/corebase/utils/AddressUtils.java
@@ -144,6 +144,9 @@ public class AddressUtils {
     }
 
     public static String getIPV4LocalAddress() {
+        if (localIPAddress != null) {
+            return localIPAddress;
+        }
         String tmpAdress = null;
         try {
             Enumeration<NetworkInterface> enumeration = NetworkInterface.getNetworkInterfaces();

--- a/tubemq-example/src/main/java/org/apache/tubemq/example/MessageConsumerExample.java
+++ b/tubemq-example/src/main/java/org/apache/tubemq/example/MessageConsumerExample.java
@@ -96,7 +96,7 @@ public final class MessageConsumerExample {
             topicTidsMap.put(topicTidStr[0], tids);
         }
         final int startFetchCount = fetchCount;
-        final ExecutorService executorService = Executors.newFixedThreadPool(fetchCount);
+        final ExecutorService executorService = Executors.newCachedThreadPool();
         for (int i = 0; i < consumerCount; i++) {
             executorService.submit(new Runnable() {
                 @Override

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/tools/cli/CliConsumer.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/tools/cli/CliConsumer.java
@@ -103,7 +103,6 @@ public class CliConsumer extends CliAbstractBase {
         addCommandOption(CliArgDef.FETCHTHREADS);
         addCommandOption(CliArgDef.CLIENTCOUNT);
         addCommandOption(CliArgDef.OUTPUTINTERVAL);
-        addCommandOption(CliArgDef.WITHOUTDELAY);
     }
 
     public boolean parseParams(String[] args) throws Exception {


### PR DESCRIPTION
Found some small bugs
1. AddressUtils.getIPV4LocalAddress() should first check whether localIPAddress has been set, and use it directly under the premise that it has been set to reduce unnecessary get operations;
2. The fetchCount parameter in MessageConsumerExample may be negative, so the executorService object should not use fetchCount as the initial value.
3. Remove the useless parameter WITHOUTDELAY