### PR TITLE
[TUBEMQ-450]TubeClientException: Generate producer id failed

### DIFF
--- a/tubemq-client/src/main/java/org/apache/tubemq/client/config/TubeClientConfig.java
+++ b/tubemq-client/src/main/java/org/apache/tubemq/client/config/TubeClientConfig.java
@@ -546,6 +546,12 @@ public class TubeClientConfig {
 
     public String toJsonString() {
         int num = 0;
+        String localAddress = null;
+        try {
+            localAddress = AddressUtils.getLocalAddress();
+        } catch (Throwable e) {
+            //
+        }
         StringBuilder sBuilder = new StringBuilder(512);
         sBuilder.append("{\"masterInfo\":[");
         for (String item : this.masterInfo.getAddrMap4Failover().keySet()) {
@@ -580,6 +586,7 @@ public class TubeClientConfig {
             .append(",\"enableUserAuthentic\":").append(this.enableUserAuthentic)
             .append(",\"usrName\":\"").append(this.usrName)
             .append("\",\"usrPassWord\":\"").append(this.usrPassWord)
+            .append("\",\"localAddress\":\"").append(localAddress)
             .append("\",").append(this.tlsConfig.toString())
             .append("}").toString();
     }


### PR DESCRIPTION
1. Check the IP type when adding the local IP input setting;
2. Cancel the requirement of compulsory setting of IP address, if it does not exist, take the first IPV4 address of the machine;
3. The client configuration adds the localAddress information printing