### PR TITLE
[TUBEMQ-544]Adjust the LICENSE statement in the client.conf files of Python and C/C++ SDK

### DIFF
--- a/tubemq-client-twins/tubemq-client-cpp/conf/client.conf
+++ b/tubemq-client-twins/tubemq-client-cpp/conf/client.conf
@@ -1,18 +1,18 @@
 ;
-; Tencent is pleased to support the open source community by making TubeMQ available.
+; Licensed to the Apache Software Foundation (ASF) under one or more
+; contributor license agreements.  See the NOTICE file distributed with
+; this work for additional information regarding copyright ownership.
+; The ASF licenses this file to You under the Apache License, Version 2.0
+; (the "License"); you may not use this file except in compliance with
+; the License.  You may obtain a copy of the License at
 ;
-; Copyright (C) 2012-2019 Tencent. All Rights Reserved.
-;
-; Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-; this file except in compliance with the License. You may obtain a copy of the
-; License at
-;
-; https://opensource.org/licenses/Apache-2.0
+;    http://www.apache.org/licenses/LICENSE-2.0
 ;
 ; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-; WARRANTIES OF ANY KIND, either express or implied.  See the License for the
-; specific language governing permissions and limitations under the License.
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
 ;
 
 [TubeMQ]

--- a/tubemq-client-twins/tubemq-client-python/src/python/tubemq/client.conf
+++ b/tubemq-client-twins/tubemq-client-python/src/python/tubemq/client.conf
@@ -1,18 +1,18 @@
 ;
-; Tencent is pleased to support the open source community by making TubeMQ available.
+; Licensed to the Apache Software Foundation (ASF) under one or more
+; contributor license agreements.  See the NOTICE file distributed with
+; this work for additional information regarding copyright ownership.
+; The ASF licenses this file to You under the Apache License, Version 2.0
+; (the "License"); you may not use this file except in compliance with
+; the License.  You may obtain a copy of the License at
 ;
-; Copyright (C) 2012-2019 Tencent. All Rights Reserved.
-;
-; Licensed under the Apache License, Version 2.0 (the "License"); you may not use
-; this file except in compliance with the License. You may obtain a copy of the
-; License at
-;
-; https://opensource.org/licenses/Apache-2.0
+;    http://www.apache.org/licenses/LICENSE-2.0
 ;
 ; Unless required by applicable law or agreed to in writing, software
-; distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
-; WARRANTIES OF ANY KIND, either express or implied.  See the License for the
-; specific language governing permissions and limitations under the License.
+; distributed under the License is distributed on an "AS IS" BASIS,
+; WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+; See the License for the specific language governing permissions and
+; limitations under the License.
 ;
 
 [TubeMQ]


### PR DESCRIPTION
The two files adopts the LICENSE version of TubeMQ when the project is open source, and is adjusted to the standard LICESNE file of Apache V2.