### PR TITLE
[TUBEMQ-546]Restore the original license header of the referenced external source files

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -265,7 +265,10 @@
                         <exclude>resources/assets/public/**</exclude>
                         <exclude>DISCLAIMER</exclude>
                         <exclude>tubemq-web/**</exclude>
-
+                        <!-- copy or modify files from other projects -->
+                        <exclude>**/tubemq-client-twins/tubemq-client-cpp/src/any.h</exclude>
+                        <exclude>**/tubemq-client-twins/tubemq-client-cpp/src/buffer.h</exclude>
+                        <exclude>**/tubemq-core/src/corebase/utils/TStringUtils.java</exclude>
                         <exclude>**/tubemq-client-twins/tubemq-client-cpp/third_party/**</exclude>
                     </excludes>
                 </configuration>

--- a/tubemq-client-twins/tubemq-client-cpp/src/any.h
+++ b/tubemq-client-twins/tubemq-client-cpp/src/any.h
@@ -1,24 +1,5 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
-
 // Copy from evpp project
-// @see https://github.com/Qihoo360/evpp/blob/master/evpp/any.h
+// @see https://github.com/Qihoo360/evpp/blob/master/evpp/any.h commit version c5038a6
 
 #ifndef TUBEMQ_CLIENT_CPP_SRC_ANY_H_
 #define TUBEMQ_CLIENT_CPP_SRC_ANY_H_

--- a/tubemq-client-twins/tubemq-client-cpp/src/buffer.h
+++ b/tubemq-client-twins/tubemq-client-cpp/src/buffer.h
@@ -1,24 +1,8 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
- */
+// Modified from muduo project http://github.com/chenshuo/muduo
+// @see https://github.com/chenshuo/muduo/blob/master/muduo/net/Buffer.h and https://github.com/chenshuo/muduo/blob/master/muduo/net/Buffer.cc
 
 // Modified from evpp
-// @see https://github.com/Qihoo360/evpp/blob/master/evpp/buffer.h
+// @see https://github.com/Qihoo360/evpp/blob/master/evpp/buffer.h, commit version b2535d7
 
 #ifndef _TUBEMQ_BUFFER_H_
 #define _TUBEMQ_BUFFER_H_

--- a/tubemq-core/src/main/java/org/apache/tubemq/corebase/utils/TStringUtils.java
+++ b/tubemq-core/src/main/java/org/apache/tubemq/corebase/utils/TStringUtils.java
@@ -1,18 +1,24 @@
-/**
- * Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements.  See the NOTICE file distributed with
- * this work for additional information regarding copyright ownership.
- * The ASF licenses this file to You under the Apache License, Version 2.0
- * (the "License"); you may not use this file except in compliance with
- * the License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+/*
+ * Copyright (c) 2002-2012 Alibaba Group Holding Limited.
+ * All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
+ */
+
+/*
+ * Modified from citrus <a href="https://github.com/webx/citrus">citrus Project</a>
+ *   file address: https://github.com/webx/citrus/blob/r3.1.4/common/util/src/
+ *                          main/java/com/alibaba/citrus/util/StringUtil.java
  */
 
 package org.apache.tubemq.corebase.utils;
@@ -28,7 +34,6 @@ import org.apache.tubemq.corebase.TokenConstants;
 
 /**
  * Utility to String operations.
- * Modified version of <a href="https://github.com/webx/citrus">citrus Project</a>
  */
 public class TStringUtils {
 


### PR DESCRIPTION
1. Restore the original license header of the referenced external source files;
2. Modify rat configuration in pom.xml to exclude the LICENSE normative check of the cited external source files;
3. Confirm that the referenced source file already has a LICENSE statement(already exists, no need to modify).