### PR TITLE
[TUBEMQ-581] Add data cache in BDB metadata Mapper implementations

### DIFF
--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/DataOpErrCode.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/DataOpErrCode.java
@@ -15,20 +15,23 @@
  * limitations under the License.
  */
 
-package org.apache.tubemq.server.common.statusdef;
+package org.apache.tubemq.server.master.metastore;
 
-public enum TopicStatus {
-    STATUS_TOPIC_UNDEFINED(-2, "Undefined."),
-    STATUS_TOPIC_OK(0, "Normal"),
-    STATUS_TOPIC_SOFT_DELETE(1, "Soft deleted"),
-    STATUS_TOPIC_SOFT_REMOVE(2, "Soft removed"),
-    STATUS_TOPIC_HARD_REMOVE(3, "Hard removed");
+
+public enum DataOpErrCode {
+    DERR_SUCCESS(200, "Success."),
+    DERR_NOT_EXIST(401, "Record not exist."),
+    DERR_EXISTED(402, "Record has existed."),
+    DERR_UNCHANGED(403, "Record not changed."),
+    DERR_STORE_ABNORMAL(501, "Store layer throw exception."),
+
+    STATUS_DISABLE(0, "Disable.");
 
     private int code;
     private String description;
 
 
-    TopicStatus(int code, String description) {
+    DataOpErrCode(int code, String description) {
         this.code = code;
         this.description = description;
     }
@@ -41,13 +44,13 @@ public enum TopicStatus {
         return description;
     }
 
-    public static TopicStatus valueOf(int code) {
-        for (TopicStatus status : TopicStatus.values()) {
+    public static DataOpErrCode valueOf(int code) {
+        for (DataOpErrCode status : DataOpErrCode.values()) {
             if (status.getCode() == code) {
                 return status;
             }
         }
-        throw new IllegalArgumentException(String.format("unknown topic status code %s", code));
+        throw new IllegalArgumentException(String.format("unknown data operate error code %s", code));
     }
 
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/BaseEntity.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/BaseEntity.java
@@ -20,9 +20,10 @@ package org.apache.tubemq.server.master.metastore.dao.entity;
 import com.google.gson.Gson;
 import java.io.Serializable;
 import java.util.Date;
+import java.util.Objects;
+import org.apache.tubemq.corebase.TBaseConstants;
 import org.apache.tubemq.corebase.utils.TStringUtils;
 import org.apache.tubemq.server.common.TServerConstants;
-
 
 
 // AbstractEntity: entity's abstract class
@@ -131,4 +132,47 @@ public class BaseEntity implements Serializable {
         return gson.toJson(this);
     }
 
+    /**
+     * Check whether the specified query item value matches
+     * Allowed query items:
+     *   dataVersionId, createUser, modifyUser
+     * @return true: matched, false: not match
+     */
+    public boolean isMatched(BaseEntity target) {
+        if (target == null) {
+            return true;
+        }
+        if ((target.getDataVersionId() != TBaseConstants.META_VALUE_UNDEFINED
+                && this.getDataVersionId() != target.getDataVersionId())
+                || (TStringUtils.isNotBlank(target.getCreateUser())
+                && !target.getCreateUser().equals(createUser))
+                || (TStringUtils.isNotBlank(target.getModifyUser())
+                && !target.getModifyUser().equals(modifyUser))) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BaseEntity)) {
+            return false;
+        }
+        BaseEntity that = (BaseEntity) o;
+        return dataVersionId == that.dataVersionId &&
+                Objects.equals(createUser, that.createUser) &&
+                Objects.equals(createDate, that.createDate) &&
+                Objects.equals(modifyUser, that.modifyUser) &&
+                Objects.equals(modifyDate, that.modifyDate) &&
+                Objects.equals(attributes, that.attributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(dataVersionId, createUser,
+                createDate, modifyUser, modifyDate, attributes);
+    }
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/BrokerConfEntity.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/BrokerConfEntity.java
@@ -18,8 +18,10 @@
 package org.apache.tubemq.server.master.metastore.dao.entity;
 
 import java.util.Date;
+import java.util.Objects;
 import org.apache.tubemq.corebase.TBaseConstants;
 import org.apache.tubemq.corebase.TokenConstants;
+import org.apache.tubemq.corebase.utils.TStringUtils;
 import org.apache.tubemq.server.common.statusdef.ManageStatus;
 import org.apache.tubemq.server.master.bdbstore.bdbentitys.BdbBrokerConfEntity;
 
@@ -264,4 +266,76 @@ public class BrokerConfEntity extends BaseEntity  {
                 .append(TokenConstants.ATTR_SEP).append(brokerTLSPort).toString();
     }
 
+    /**
+     * Check whether the specified query item value matches
+     * Allowed query items:
+     *   brokerId, brokerIp, brokerPort, brokerTLSPort, regionId, groupId
+     *   manageStatus, brokerWebPort
+     * @return true: matched, false: not match
+     */
+    public boolean isMatched(BrokerConfEntity target) {
+        if (target == null) {
+            return true;
+        }
+        if (!super.isMatched(target)) {
+            return false;
+        }
+        if ((target.getBrokerId() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getBrokerId() != this.brokerId)
+                || (TStringUtils.isNotBlank(target.getBrokerIp())
+                && !target.getBrokerIp().equals(this.brokerIp))
+                || (target.getBrokerPort() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getBrokerPort() != this.brokerPort)
+                || (target.getBrokerTLSPort() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getBrokerTLSPort() != this.brokerTLSPort)
+                || (target.getRegionId() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getRegionId() != this.regionId)
+                || (target.getGroupId() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getGroupId() != this.groupId)
+                || (target.getManageStatus() != ManageStatus.STATUS_MANAGE_UNDEFINED
+                && target.getManageStatus() != this.manageStatus)
+                || (target.getBrokerWebPort() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getBrokerWebPort() != this.brokerWebPort)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof BrokerConfEntity)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        BrokerConfEntity entity = (BrokerConfEntity) o;
+        return brokerId == entity.brokerId &&
+                brokerPort == entity.brokerPort &&
+                brokerTLSPort == entity.brokerTLSPort &&
+                brokerWebPort == entity.brokerWebPort &&
+                isConfDataUpdated == entity.isConfDataUpdated &&
+                isBrokerLoaded == entity.isBrokerLoaded &&
+                regionId == entity.regionId &&
+                groupId == entity.groupId &&
+                Objects.equals(brokerIp, entity.brokerIp) &&
+                manageStatus == entity.manageStatus &&
+                Objects.equals(topicProps, entity.topicProps) &&
+                Objects.equals(brokerAddress, entity.brokerAddress) &&
+                Objects.equals(brokerFullInfo, entity.brokerFullInfo) &&
+                Objects.equals(brokerSimpleInfo, entity.brokerSimpleInfo) &&
+                Objects.equals(brokerTLSSimpleInfo, entity.brokerTLSSimpleInfo) &&
+                Objects.equals(brokerTLSFullInfo, entity.brokerTLSFullInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), brokerId, brokerIp, brokerPort, brokerTLSPort,
+                brokerWebPort, manageStatus, isConfDataUpdated, isBrokerLoaded, regionId,
+                groupId, topicProps, brokerAddress, brokerFullInfo, brokerSimpleInfo,
+                brokerTLSSimpleInfo, brokerTLSFullInfo);
+    }
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/ClusterSettingEntity.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/ClusterSettingEntity.java
@@ -17,10 +17,12 @@
 
 package org.apache.tubemq.server.master.metastore.dao.entity;
 
+import java.util.Objects;
 import org.apache.tubemq.corebase.TBaseConstants;
 import org.apache.tubemq.server.common.statusdef.EnableStatus;
 import org.apache.tubemq.server.master.bdbstore.bdbentitys.BdbClusterSettingEntity;
 import org.apache.tubemq.server.master.metastore.TStoreConstants;
+
 
 
 /*
@@ -179,4 +181,34 @@ public class ClusterSettingEntity extends BaseEntity {
         this.clsDefTopicProps = clsDefTopicProps;
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof ClusterSettingEntity)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        ClusterSettingEntity entity = (ClusterSettingEntity) o;
+        return brokerPort == entity.brokerPort &&
+                brokerTLSPort == entity.brokerTLSPort &&
+                brokerWebPort == entity.brokerWebPort &&
+                maxMsgSizeInB == entity.maxMsgSizeInB &&
+                qryPriorityId == entity.qryPriorityId &&
+                gloFlowCtrlRuleCnt == entity.gloFlowCtrlRuleCnt &&
+                recordKey.equals(entity.recordKey) &&
+                Objects.equals(clsDefTopicProps, entity.clsDefTopicProps) &&
+                gloFlowCtrlStatus == entity.gloFlowCtrlStatus &&
+                Objects.equals(gloFlowCtrlRuleInfo, entity.gloFlowCtrlRuleInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), recordKey, brokerPort, brokerTLSPort,
+                brokerWebPort, clsDefTopicProps, maxMsgSizeInB, qryPriorityId,
+                gloFlowCtrlStatus, gloFlowCtrlRuleCnt, gloFlowCtrlRuleInfo);
+    }
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/GroupBlackListEntity.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/GroupBlackListEntity.java
@@ -18,8 +18,10 @@
 package org.apache.tubemq.server.master.metastore.dao.entity;
 
 import java.util.Date;
+import java.util.Objects;
 import org.apache.tubemq.corebase.TBaseConstants;
 import org.apache.tubemq.corebase.TokenConstants;
+import org.apache.tubemq.corebase.utils.TStringUtils;
 import org.apache.tubemq.server.master.bdbstore.bdbentitys.BdbBlackGroupEntity;
 
 
@@ -87,4 +89,48 @@ public class GroupBlackListEntity extends BaseEntity {
         return reason;
     }
 
+    /**
+     * Check whether the specified query item value matches
+     * Allowed query items:
+     *   groupName, topicName
+     * @return true: matched, false: not match
+     */
+    public boolean isMatched(GroupBlackListEntity target) {
+        if (target == null) {
+            return true;
+        }
+        if (!super.isMatched(target)) {
+            return false;
+        }
+        if ((TStringUtils.isNotBlank(target.getTopicName())
+                && !target.getTopicName().equals(this.topicName))
+                || (TStringUtils.isNotBlank(target.getGroupName())
+                && !target.getGroupName().equals(this.groupName))) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof GroupBlackListEntity)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        GroupBlackListEntity that = (GroupBlackListEntity) o;
+        return Objects.equals(recordKey, that.recordKey) &&
+                Objects.equals(topicName, that.topicName) &&
+                Objects.equals(groupName, that.groupName) &&
+                Objects.equals(reason, that.reason);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), recordKey, topicName, groupName, reason);
+    }
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/GroupConfigEntity.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/GroupConfigEntity.java
@@ -18,7 +18,9 @@
 package org.apache.tubemq.server.master.metastore.dao.entity;
 
 import java.util.Date;
+import java.util.Objects;
 import org.apache.tubemq.corebase.TBaseConstants;
+import org.apache.tubemq.corebase.utils.TStringUtils;
 import org.apache.tubemq.server.common.statusdef.EnableStatus;
 import org.apache.tubemq.server.master.bdbstore.bdbentitys.BdbGroupFlowCtrlEntity;
 
@@ -149,4 +151,76 @@ public class GroupConfigEntity extends BaseEntity {
         this.allowedBrokerClientRate = allowedBrokerClientRate;
     }
 
+    public EnableStatus getResCheckStatus() {
+        return resCheckStatus;
+    }
+
+    public void setResCheckStatus(EnableStatus resCheckStatus) {
+        this.resCheckStatus = resCheckStatus;
+    }
+
+    public EnableStatus getFlowCtrlStatus() {
+        return flowCtrlStatus;
+    }
+
+    public void setFlowCtrlStatus(EnableStatus flowCtrlStatus) {
+        this.flowCtrlStatus = flowCtrlStatus;
+    }
+
+    /**
+     * Check whether the specified query item value matches
+     * Allowed query items:
+     *   groupName, qryPriorityId, resCheckStatus,
+     *   flowCtrlStatus, allowedBrokerClientRate
+     * @return true: matched, false: not match
+     */
+    public boolean isMatched(GroupConfigEntity target) {
+        if (target == null) {
+            return true;
+        }
+        if (!super.isMatched(target)) {
+            return false;
+        }
+        if ((target.getQryPriorityId() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getQryPriorityId() != this.qryPriorityId)
+                || (TStringUtils.isNotBlank(target.getGroupName())
+                && !target.getGroupName().equals(this.groupName))
+                || (target.getResCheckStatus() != EnableStatus.STATUS_UNDEFINE
+                && target.getResCheckStatus() != this.resCheckStatus)
+                || (target.getFlowCtrlStatus() != EnableStatus.STATUS_UNDEFINE
+                && target.getFlowCtrlStatus() != this.flowCtrlStatus)
+                || (target.getAllowedBrokerClientRate() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getAllowedBrokerClientRate() != this.allowedBrokerClientRate)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof GroupConfigEntity)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        GroupConfigEntity that = (GroupConfigEntity) o;
+        return allowedBrokerClientRate == that.allowedBrokerClientRate &&
+                qryPriorityId == that.qryPriorityId &&
+                ruleCnt == that.ruleCnt &&
+                groupName.equals(that.groupName) &&
+                resCheckStatus == that.resCheckStatus &&
+                flowCtrlStatus == that.flowCtrlStatus &&
+                Objects.equals(flowCtrlInfo, that.flowCtrlInfo);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), groupName, resCheckStatus,
+                allowedBrokerClientRate, qryPriorityId, flowCtrlStatus,
+                ruleCnt, flowCtrlInfo);
+    }
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/GroupFilterCtrlEntity.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/GroupFilterCtrlEntity.java
@@ -18,8 +18,10 @@
 package org.apache.tubemq.server.master.metastore.dao.entity;
 
 import java.util.Date;
+import java.util.Objects;
 import org.apache.tubemq.corebase.TBaseConstants;
 import org.apache.tubemq.corebase.TokenConstants;
+import org.apache.tubemq.corebase.utils.TStringUtils;
 import org.apache.tubemq.server.common.statusdef.EnableStatus;
 import org.apache.tubemq.server.master.bdbstore.bdbentitys.BdbGroupFilterCondEntity;
 
@@ -125,4 +127,56 @@ public class GroupFilterCtrlEntity extends BaseEntity {
         this.filterCondStr = filterCondStr;
     }
 
+    public EnableStatus getFilterConsumeStatus() {
+        return filterConsumeStatus;
+    }
+
+    /**
+     * Check whether the specified query item value matches
+     * Allowed query items:
+     *   topicName, groupName, filterConsumeStatus
+     * @return true: matched, false: not match
+     */
+    public boolean isMatched(GroupFilterCtrlEntity target) {
+        if (target == null) {
+            return true;
+        }
+        if (!super.isMatched(target)) {
+            return false;
+        }
+        if ((TStringUtils.isNotBlank(target.getTopicName())
+                && !target.getTopicName().equals(this.topicName))
+                || (TStringUtils.isNotBlank(target.getGroupName())
+                && !target.getGroupName().equals(this.groupName))
+                || (target.getFilterConsumeStatus() != EnableStatus.STATUS_UNDEFINE
+                && target.getFilterConsumeStatus() != this.filterConsumeStatus)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof GroupFilterCtrlEntity)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        GroupFilterCtrlEntity that = (GroupFilterCtrlEntity) o;
+        return recordKey.equals(that.recordKey) &&
+                Objects.equals(topicName, that.topicName) &&
+                Objects.equals(groupName, that.groupName) &&
+                filterConsumeStatus == that.filterConsumeStatus &&
+                Objects.equals(filterCondStr, that.filterCondStr);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), recordKey,
+                topicName, groupName, filterConsumeStatus, filterCondStr);
+    }
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/TopicConfEntity.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/TopicConfEntity.java
@@ -18,8 +18,10 @@
 package org.apache.tubemq.server.master.metastore.dao.entity;
 
 import java.util.Date;
+import java.util.Objects;
 import org.apache.tubemq.corebase.TBaseConstants;
 import org.apache.tubemq.corebase.TokenConstants;
+import org.apache.tubemq.corebase.utils.TStringUtils;
 import org.apache.tubemq.server.common.statusdef.TopicStatus;
 import org.apache.tubemq.server.master.bdbstore.bdbentitys.BdbTopicConfEntity;
 
@@ -35,7 +37,7 @@ public class TopicConfEntity extends BaseEntity {
     private int brokerId = TBaseConstants.META_VALUE_UNDEFINED;
     // topic id, require globally unique
     private int topicId = TBaseConstants.META_VALUE_UNDEFINED;
-    private TopicStatus deployStatus = TopicStatus.STATUS_TOPIC_OK;  // topic status
+    private TopicStatus deployStatus = TopicStatus.STATUS_TOPIC_UNDEFINED;  // topic status
     private TopicPropGroup topicProps = null;
 
 
@@ -139,5 +141,57 @@ public class TopicConfEntity extends BaseEntity {
 
     public boolean isValidTopicStatus() {
         return this.deployStatus == TopicStatus.STATUS_TOPIC_OK;
+    }
+
+    /**
+     * Check whether the specified query item value matches
+     * Allowed query items:
+     *   brokerId, topicId, topicName, topicStatus
+     * @return true: matched, false: not match
+     */
+    public boolean isMatched(TopicConfEntity target) {
+        if (target == null) {
+            return true;
+        }
+        if (!super.isMatched(target)) {
+            return false;
+        }
+        if ((target.getBrokerId() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getBrokerId() != this.brokerId)
+                || (target.getTopicId() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getTopicId() != this.topicId)
+                || (TStringUtils.isNotBlank(target.getTopicName())
+                && !target.getTopicName().equals(this.topicName))
+                || (target.getTopicStatus() != TopicStatus.STATUS_TOPIC_UNDEFINED
+                && target.getTopicStatus() != this.deployStatus)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TopicConfEntity)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        TopicConfEntity that = (TopicConfEntity) o;
+        return brokerId == that.brokerId &&
+                topicId == that.topicId &&
+                Objects.equals(recordKey, that.recordKey) &&
+                Objects.equals(topicName, that.topicName) &&
+                deployStatus == that.deployStatus &&
+                Objects.equals(topicProps, that.topicProps);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), recordKey,
+                topicName, brokerId, topicId, deployStatus, topicProps);
     }
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/TopicCtrlEntity.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/TopicCtrlEntity.java
@@ -18,7 +18,9 @@
 package org.apache.tubemq.server.master.metastore.dao.entity;
 
 import java.util.Date;
+import java.util.Objects;
 import org.apache.tubemq.corebase.TBaseConstants;
+import org.apache.tubemq.corebase.utils.TStringUtils;
 import org.apache.tubemq.server.common.statusdef.EnableStatus;
 import org.apache.tubemq.server.master.bdbstore.bdbentitys.BdbTopicAuthControlEntity;
 
@@ -91,5 +93,63 @@ public class TopicCtrlEntity extends BaseEntity {
         } else {
             this.authCtrlStatus = EnableStatus.STATUS_DISABLE;
         }
+    }
+
+    public EnableStatus getAuthCtrlStatus() {
+        return authCtrlStatus;
+    }
+
+    public int getMaxMsgSizeInB() {
+        return maxMsgSizeInB;
+    }
+
+    public void setMaxMsgSizeInB(int maxMsgSizeInB) {
+        this.maxMsgSizeInB = maxMsgSizeInB;
+    }
+
+    /**
+     * Check whether the specified query item value matches
+     * Allowed query items:
+     *   topicName, maxMsgSizeInB, authCtrlStatus
+     * @return true: matched, false: not match
+     */
+    public boolean isMatched(TopicCtrlEntity target) {
+        if (target == null) {
+            return true;
+        }
+        if (!super.isMatched(target)) {
+            return false;
+        }
+        if ((target.getMaxMsgSizeInB() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getMaxMsgSizeInB() != this.maxMsgSizeInB)
+                || (TStringUtils.isNotBlank(target.getTopicName())
+                && !target.getTopicName().equals(this.topicName))
+                || (target.getAuthCtrlStatus() != EnableStatus.STATUS_UNDEFINE
+                && target.getAuthCtrlStatus() != this.authCtrlStatus)) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TopicCtrlEntity)) {
+            return false;
+        }
+        if (!super.equals(o)) {
+            return false;
+        }
+        TopicCtrlEntity that = (TopicCtrlEntity) o;
+        return maxMsgSizeInB == that.maxMsgSizeInB &&
+                topicName.equals(that.topicName) &&
+                authCtrlStatus == that.authCtrlStatus;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(super.hashCode(), topicName, authCtrlStatus, maxMsgSizeInB);
     }
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/TopicPropGroup.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/entity/TopicPropGroup.java
@@ -18,8 +18,9 @@
 package org.apache.tubemq.server.master.metastore.dao.entity;
 
 import java.io.Serializable;
+import java.util.Objects;
 import org.apache.tubemq.corebase.TBaseConstants;
-
+import org.apache.tubemq.corebase.utils.TStringUtils;
 
 
 /*
@@ -166,5 +167,70 @@ public class TopicPropGroup implements Serializable {
 
     public int getDataStoreType() {
         return dataStoreType;
+    }
+
+    /**
+     * Check whether the specified query item value matches
+     * Allowed query items:
+     *   numTopicStores, numPartitions, unflushThreshold, unflushInterval, unflushDataHold,
+     *   memCacheMsgSizeInMB, memCacheMsgCntInK, memCacheFlushIntvl, deletePolicy
+     * @return true: matched, false: not match
+     */
+    public boolean isMatched(TopicPropGroup target) {
+        if (target == null) {
+            return true;
+        }
+        if ((target.getNumTopicStores() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getNumTopicStores() != this.numTopicStores)
+                || (target.getNumPartitions() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getNumPartitions() != this.numPartitions)
+                || (target.getUnflushThreshold() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getUnflushThreshold() != this.unflushThreshold)
+                || (target.getUnflushInterval() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getUnflushInterval() != this.unflushInterval)
+                || (target.getUnflushDataHold() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getUnflushDataHold() != this.unflushDataHold)
+                || (target.getMemCacheMsgSizeInMB() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getMemCacheMsgSizeInMB() != this.memCacheMsgSizeInMB)
+                || (target.getMemCacheMsgCntInK() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getMemCacheMsgCntInK() != this.memCacheMsgCntInK)
+                || (target.getMemCacheFlushIntvl() != TBaseConstants.META_VALUE_UNDEFINED
+                && target.getMemCacheFlushIntvl() != this.memCacheFlushIntvl)
+                || (TStringUtils.isNotBlank(target.getDeletePolicy())
+                && !target.getDeletePolicy().equals(this.deletePolicy))) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof TopicPropGroup)) {
+            return false;
+        }
+        TopicPropGroup that = (TopicPropGroup) o;
+        return numTopicStores == that.numTopicStores &&
+                numPartitions == that.numPartitions &&
+                unflushThreshold == that.unflushThreshold &&
+                unflushInterval == that.unflushInterval &&
+                unflushDataHold == that.unflushDataHold &&
+                memCacheMsgSizeInMB == that.memCacheMsgSizeInMB &&
+                memCacheMsgCntInK == that.memCacheMsgCntInK &&
+                memCacheFlushIntvl == that.memCacheFlushIntvl &&
+                acceptPublish == that.acceptPublish &&
+                acceptSubscribe == that.acceptSubscribe &&
+                dataStoreType == that.dataStoreType &&
+                Objects.equals(deletePolicy, that.deletePolicy) &&
+                Objects.equals(dataPath, that.dataPath);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(numTopicStores, numPartitions, unflushThreshold, unflushInterval,
+                unflushDataHold, memCacheMsgSizeInMB, memCacheMsgCntInK, memCacheFlushIntvl,
+                acceptPublish, acceptSubscribe, deletePolicy, dataStoreType, dataPath);
     }
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/AbstractMapper.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/AbstractMapper.java
@@ -18,14 +18,13 @@
 package org.apache.tubemq.server.master.metastore.dao.mapper;
 
 import org.apache.tubemq.server.common.exception.LoadMetaException;
-import org.apache.tubemq.server.common.utils.ProcessResult;
 
 
 public interface AbstractMapper {
 
     void close();
 
-    void loadConfig(ProcessResult result) throws LoadMetaException;
+    void loadConfig() throws LoadMetaException;
 
 
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/BrokerConfigMapper.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/BrokerConfigMapper.java
@@ -17,15 +17,21 @@
 
 package org.apache.tubemq.server.master.metastore.dao.mapper;
 
+import java.util.Map;
 import org.apache.tubemq.server.common.utils.ProcessResult;
 import org.apache.tubemq.server.master.metastore.dao.entity.BrokerConfEntity;
 
 
+
 public interface BrokerConfigMapper extends AbstractMapper {
 
-    boolean putBrokerConfig(BrokerConfEntity memEntity, ProcessResult result);
+    boolean addBrokerConf(BrokerConfEntity memEntity, ProcessResult result);
 
-    boolean delBrokerConfig(int brokerId);
+    boolean updBrokerConf(BrokerConfEntity memEntity, ProcessResult result);
 
+    boolean delBrokerConf(int brokerId);
 
+    Map<Integer, BrokerConfEntity> getBrokerConfByBrokerId(BrokerConfEntity qryEntity);
+
+    BrokerConfEntity getBrokerConfByBrokerId(int brokerId);
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/ClusterConfigMapper.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/ClusterConfigMapper.java
@@ -23,7 +23,11 @@ import org.apache.tubemq.server.master.metastore.dao.entity.ClusterSettingEntity
 
 public interface ClusterConfigMapper extends AbstractMapper {
 
-    boolean putClusterConfig(ClusterSettingEntity memEntity, ProcessResult result);
+    boolean addClusterConfig(ClusterSettingEntity memEntity, ProcessResult result);
 
-    boolean delClusterConfig(String key);
+    boolean updClusterConfig(ClusterSettingEntity memEntity, ProcessResult result);
+
+    ClusterSettingEntity getClusterConfig();
+
+    boolean delClusterConfig();
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/GroupBlackListMapper.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/GroupBlackListMapper.java
@@ -17,15 +17,29 @@
 
 package org.apache.tubemq.server.master.metastore.dao.mapper;
 
+import java.util.List;
 import org.apache.tubemq.server.common.utils.ProcessResult;
 import org.apache.tubemq.server.master.metastore.dao.entity.GroupBlackListEntity;
 
 
+
+
 public interface GroupBlackListMapper extends AbstractMapper {
 
-    boolean putGroupBlackListConfig(GroupBlackListEntity memEntity, ProcessResult result);
+    // about group blacklist api
+    boolean addGroupBlackListConf(GroupBlackListEntity entity, ProcessResult result);
 
-    boolean delGroupBlackListConfig(String key);
+    boolean updGroupBlackListConf(GroupBlackListEntity entity, ProcessResult result);
+
+    boolean delGroupBlackListConf(String recordKey);
+
+    boolean delGroupBlackListConfByGroupName(String groupName);
+
+    List<GroupBlackListEntity> getGrpBlkLstConfByGroupName(String groupName);
+
+    List<GroupBlackListEntity> getGrpBlkLstConfByTopicName(String topicName);
+
+    List<GroupBlackListEntity> getGroupBlackListConf(GroupBlackListEntity qryEntity);
 
 
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/GroupFilterCtrlMapper.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/GroupFilterCtrlMapper.java
@@ -17,15 +17,22 @@
 
 package org.apache.tubemq.server.master.metastore.dao.mapper;
 
+import java.util.List;
 import org.apache.tubemq.server.common.utils.ProcessResult;
 import org.apache.tubemq.server.master.metastore.dao.entity.GroupFilterCtrlEntity;
 
 
+
 public interface GroupFilterCtrlMapper extends AbstractMapper {
 
-    boolean putGroupFilterCtrlConfig(GroupFilterCtrlEntity memEntity, ProcessResult result);
+    boolean addGroupFilterCtrlConf(GroupFilterCtrlEntity entity, ProcessResult result);
 
-    boolean delGroupFilterCtrlConfig(String key);
+    boolean updGroupFilterCtrlConf(GroupFilterCtrlEntity entity, ProcessResult result);
 
+    boolean delGroupFilterCtrlConf(String recordKey);
+
+    List<GroupFilterCtrlEntity> getGroupFilterCtrlConf(String groupName);
+
+    List<GroupFilterCtrlEntity> getGroupFilterCtrlConf(GroupFilterCtrlEntity qryEntity);
 
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/TopicConfigMapper.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/TopicConfigMapper.java
@@ -17,15 +17,21 @@
 
 package org.apache.tubemq.server.master.metastore.dao.mapper;
 
+import java.util.List;
 import org.apache.tubemq.server.common.utils.ProcessResult;
 import org.apache.tubemq.server.master.metastore.dao.entity.TopicConfEntity;
 
 
+
 public interface TopicConfigMapper extends AbstractMapper {
 
-    boolean putTopicConfig(TopicConfEntity memEntity, ProcessResult result);
+    boolean addTopicConf(TopicConfEntity entity, ProcessResult result);
 
-    boolean delTopicConfig(String key);
+    boolean updTopicConf(TopicConfEntity entity, ProcessResult result);
+
+    boolean delTopicConf(String recordKey);
+
+    List<TopicConfEntity> getTopicConf(TopicConfEntity qryEntity);
 
 
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/TopicCtrlMapper.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/dao/mapper/TopicCtrlMapper.java
@@ -17,16 +17,25 @@
 
 package org.apache.tubemq.server.master.metastore.dao.mapper;
 
+import java.util.List;
 import org.apache.tubemq.server.common.utils.ProcessResult;
+import org.apache.tubemq.server.master.metastore.dao.entity.TopicConfEntity;
 import org.apache.tubemq.server.master.metastore.dao.entity.TopicCtrlEntity;
+
 
 
 
 public interface TopicCtrlMapper extends AbstractMapper {
 
-    boolean putTopicCtrlConfig(TopicCtrlEntity memEntity, ProcessResult result);
+    boolean addTopicCtrlConf(TopicCtrlEntity entity, ProcessResult result);
 
-    boolean delTopicCtrlConfig(String key);
+    boolean updTopicCtrlConf(TopicCtrlEntity entity, ProcessResult result);
+
+    boolean delTopicCtrlConf(String recordKey);
+
+    TopicCtrlEntity getTopicCtrlConf(String topicName);
+
+    List<TopicCtrlEntity> getTopicCtrlConf(TopicConfEntity qryEntity);
 
 
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/impl/bdbimpl/BdbGroupBlackListMapperImpl.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/impl/bdbimpl/BdbGroupBlackListMapperImpl.java
@@ -23,12 +23,16 @@ import com.sleepycat.persist.EntityCursor;
 import com.sleepycat.persist.EntityStore;
 import com.sleepycat.persist.PrimaryIndex;
 import com.sleepycat.persist.StoreConfig;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.tubemq.corebase.TBaseConstants;
+import org.apache.tubemq.corebase.utils.ConcurrentHashSet;
 import org.apache.tubemq.server.common.exception.LoadMetaException;
 import org.apache.tubemq.server.common.utils.ProcessResult;
 import org.apache.tubemq.server.master.bdbstore.bdbentitys.BdbBlackGroupEntity;
+import org.apache.tubemq.server.master.metastore.DataOpErrCode;
 import org.apache.tubemq.server.master.metastore.dao.entity.GroupBlackListEntity;
 import org.apache.tubemq.server.master.metastore.dao.mapper.GroupBlackListMapper;
 import org.slf4j.Logger;
@@ -38,14 +42,18 @@ import org.slf4j.LoggerFactory;
 
 public class BdbGroupBlackListMapperImpl implements GroupBlackListMapper {
 
-
     private static final Logger logger =
             LoggerFactory.getLogger(BdbGroupBlackListMapperImpl.class);
-
-
     // consumer group black list store
     private EntityStore blackGroupStore;
     private PrimaryIndex<String/* recordKey */, BdbBlackGroupEntity> blackGroupIndex;
+    private ConcurrentHashMap<String/* recordKey */, GroupBlackListEntity>
+            groupBlackListCache = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<String/* topicName */, ConcurrentHashSet<String>>
+            groupBlackListTopicCache = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<String/* groupName */, ConcurrentHashSet<String> >
+            groupBlackListGroupCache = new ConcurrentHashMap<>();
+
 
 
     public BdbGroupBlackListMapperImpl(ReplicatedEnvironment repEnv, StoreConfig storeConfig) {
@@ -57,6 +65,9 @@ public class BdbGroupBlackListMapperImpl implements GroupBlackListMapper {
 
     @Override
     public void close() {
+        // clear cache data
+        clearCacheData();
+        // close store object
         if (blackGroupStore != null) {
             try {
                 blackGroupStore.close();
@@ -68,12 +79,14 @@ public class BdbGroupBlackListMapperImpl implements GroupBlackListMapper {
     }
 
     @Override
-    public void loadConfig(ProcessResult result) throws LoadMetaException {
+    public void loadConfig() throws LoadMetaException {
         long count = 0L;
-        Map<String, GroupBlackListEntity> metaDataMap = new HashMap<>();
         EntityCursor<BdbBlackGroupEntity> cursor = null;
         logger.info("[BDB Impl] load blacklist configure start...");
         try {
+            // clear cache data
+            clearCacheData();
+            // read data from bdb
             cursor = blackGroupIndex.entities();
             for (BdbBlackGroupEntity bdbEntity : cursor) {
                 if (bdbEntity == null) {
@@ -82,11 +95,10 @@ public class BdbGroupBlackListMapperImpl implements GroupBlackListMapper {
                 }
                 GroupBlackListEntity memEntity =
                         new GroupBlackListEntity(bdbEntity);
-                metaDataMap.put(memEntity.getRecordKey(), memEntity);
+                addOrUpdCacheRecord(memEntity);
                 count++;
             }
             logger.info("[BDB Impl] total blacklist configure records are {}", count);
-            result.setSuccResult(metaDataMap);
         } catch (Exception e) {
             logger.error("[BDB Impl] load blacklist configure failure ", e);
             throw new LoadMetaException(e.getMessage());
@@ -98,6 +110,126 @@ public class BdbGroupBlackListMapperImpl implements GroupBlackListMapper {
         logger.info("[BDB Impl] load blacklist configure successfully...");
     }
 
+    @Override
+    public boolean addGroupBlackListConf(GroupBlackListEntity memEntity, ProcessResult result) {
+        GroupBlackListEntity curEntity =
+                groupBlackListCache.get(memEntity.getRecordKey());
+        if (curEntity != null) {
+            result.setFailResult(DataOpErrCode.DERR_EXISTED.getCode(),
+                    new StringBuilder(TBaseConstants.BUILDER_DEFAULT_SIZE)
+                            .append("The blacklist ").append(memEntity.getRecordKey())
+                            .append("'s configure already exists, please delete it first!")
+                            .toString());
+            return result.isSuccess();
+        }
+        if (putGroupBlackListConfig2Bdb(memEntity, result)) {
+            addOrUpdCacheRecord(memEntity);
+        }
+        return result.isSuccess();
+    }
+
+    @Override
+    public boolean updGroupBlackListConf(GroupBlackListEntity memEntity, ProcessResult result) {
+        GroupBlackListEntity curEntity =
+                groupBlackListCache.get(memEntity.getRecordKey());
+        if (curEntity == null) {
+            result.setFailResult(DataOpErrCode.DERR_NOT_EXIST.getCode(),
+                    new StringBuilder(TBaseConstants.BUILDER_DEFAULT_SIZE)
+                            .append("The blacklist ").append(memEntity.getRecordKey())
+                            .append("'s configure is not exists, please add record first!")
+                            .toString());
+            return result.isSuccess();
+        }
+        if (curEntity.equals(memEntity)) {
+            result.setFailResult(DataOpErrCode.DERR_UNCHANGED.getCode(),
+                    new StringBuilder(TBaseConstants.BUILDER_DEFAULT_SIZE)
+                            .append("The blacklist ").append(memEntity.getRecordKey())
+                            .append("'s configure have not changed, please delete it first!")
+                            .toString());
+            return result.isSuccess();
+        }
+        if (putGroupBlackListConfig2Bdb(memEntity, result)) {
+            addOrUpdCacheRecord(memEntity);
+        }
+        return result.isSuccess();
+    }
+
+    @Override
+    public boolean delGroupBlackListConf(String recordKey) {
+        GroupBlackListEntity curEntity =
+                groupBlackListCache.get(recordKey);
+        if (curEntity == null) {
+            return true;
+        }
+        delGroupBlackListConfigFromBdb(recordKey);
+        delCacheRecord(recordKey);
+        return true;
+    }
+
+    @Override
+    public List<GroupBlackListEntity> getGrpBlkLstConfByGroupName(String groupName) {
+        ConcurrentHashSet<String> keySet =
+                groupBlackListGroupCache.get(groupName);
+        if (keySet == null || keySet.isEmpty()) {
+            return Collections.emptyList();
+        }
+        GroupBlackListEntity entity;
+        List<GroupBlackListEntity> result = new ArrayList<>();
+        for (String recordKey : keySet) {
+            entity = groupBlackListCache.get(recordKey);
+            if (entity != null) {
+                result.add(entity);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public boolean delGroupBlackListConfByGroupName(String groupName) {
+        List<GroupBlackListEntity> curEntitys =
+                getGrpBlkLstConfByTopicName(groupName);
+        if (curEntitys.isEmpty()) {
+            return true;
+        }
+        for (GroupBlackListEntity entity : curEntitys) {
+            delGroupBlackListConf(entity.getRecordKey());
+        }
+        return true;
+    }
+
+    @Override
+    public List<GroupBlackListEntity> getGrpBlkLstConfByTopicName(String topicName) {
+        ConcurrentHashSet<String> keySet =
+                groupBlackListTopicCache.get(topicName);
+        if (keySet == null || keySet.isEmpty()) {
+            return Collections.emptyList();
+        }
+        GroupBlackListEntity entity;
+        List<GroupBlackListEntity> result = new ArrayList<>();
+        for (String recordKey : keySet) {
+            entity = groupBlackListCache.get(recordKey);
+            if (entity != null) {
+                result.add(entity);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public List<GroupBlackListEntity> getGroupBlackListConf(GroupBlackListEntity qryEntity) {
+        List<GroupBlackListEntity> retEntitys = new ArrayList<>();
+        if (qryEntity == null) {
+            retEntitys.addAll(groupBlackListCache.values());
+        } else {
+            for (GroupBlackListEntity entity : groupBlackListCache.values()) {
+                if (entity.isMatched(qryEntity)) {
+                    retEntitys.add(entity);
+                }
+            }
+        }
+        return retEntitys;
+    }
+
     /**
      * Put blacklist configure info into bdb store
      *
@@ -105,26 +237,25 @@ public class BdbGroupBlackListMapperImpl implements GroupBlackListMapper {
      * @param result process result with old value
      * @return
      */
-    @Override
-    public boolean putGroupBlackListConfig(GroupBlackListEntity memEntity, ProcessResult result) {
+    private boolean putGroupBlackListConfig2Bdb(GroupBlackListEntity memEntity,
+                                                ProcessResult result) {
         BdbBlackGroupEntity retData = null;
-        BdbBlackGroupEntity bdbEntity =
-                memEntity.buildBdbBlackListEntity();
+        BdbBlackGroupEntity bdbEntity = memEntity.buildBdbBlackListEntity();
         try {
             retData = blackGroupIndex.put(bdbEntity);
         } catch (Throwable e) {
             logger.error("[BDB Impl] put blacklist configure failure ", e);
-            result.setFailResult(new StringBuilder(TBaseConstants.BUILDER_DEFAULT_SIZE)
-                    .append("Put blacklist configure failure: ")
-                    .append(e.getMessage()).toString());
+            result.setFailResult(DataOpErrCode.DERR_STORE_ABNORMAL.getCode(),
+                    new StringBuilder(TBaseConstants.BUILDER_DEFAULT_SIZE)
+                            .append("Put blacklist configure failure: ")
+                            .append(e.getMessage()).toString());
             return result.isSuccess();
         }
         result.setSuccResult(retData == null);
         return result.isSuccess();
     }
 
-    @Override
-    public boolean delGroupBlackListConfig(String recordKey) {
+    private boolean delGroupBlackListConfigFromBdb(String recordKey) {
         try {
             blackGroupIndex.delete(recordKey);
         } catch (Throwable e) {
@@ -132,6 +263,62 @@ public class BdbGroupBlackListMapperImpl implements GroupBlackListMapper {
             return false;
         }
         return true;
+    }
+
+
+    private void delCacheRecord(String recordKey) {
+        GroupBlackListEntity curEntity = groupBlackListCache.get(recordKey);
+        if (curEntity == null) {
+            return;
+        }
+        // add topic index
+        ConcurrentHashSet<String> keySet =
+                groupBlackListTopicCache.get(curEntity.getTopicName());
+        if (keySet != null) {
+            keySet.remove(recordKey);
+            if (keySet.isEmpty()) {
+                groupBlackListTopicCache.remove(curEntity.getTopicName());
+            }
+        }
+        // delete group index
+        keySet = groupBlackListGroupCache.remove(curEntity.getGroupName());
+        if (keySet != null) {
+            keySet.remove(recordKey);
+            if (keySet.isEmpty()) {
+                groupBlackListGroupCache.remove(curEntity.getGroupName());
+            }
+        }
+    }
+
+    private void addOrUpdCacheRecord(GroupBlackListEntity entity) {
+        groupBlackListCache.put(entity.getRecordKey(), entity);
+        // add topic index map
+        ConcurrentHashSet<String> keySet =
+                groupBlackListTopicCache.get(entity.getTopicName());
+        if (keySet == null) {
+            ConcurrentHashSet<String> tmpSet = new ConcurrentHashSet<>();
+            keySet = groupBlackListTopicCache.putIfAbsent(entity.getTopicName(), tmpSet);
+            if (keySet == null) {
+                keySet = tmpSet;
+            }
+        }
+        keySet.add(entity.getRecordKey());
+        // add group index map
+        keySet = groupBlackListGroupCache.get(entity.getGroupName());
+        if (keySet == null) {
+            ConcurrentHashSet<String> tmpSet = new ConcurrentHashSet<>();
+            keySet = groupBlackListGroupCache.putIfAbsent(entity.getGroupName(), tmpSet);
+            if (keySet == null) {
+                keySet = tmpSet;
+            }
+        }
+        keySet.add(entity.getRecordKey());
+    }
+
+    private void clearCacheData() {
+        groupBlackListTopicCache.clear();
+        groupBlackListGroupCache.clear();
+        groupBlackListCache.clear();
     }
 
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/impl/bdbimpl/BdbTopicConfigMapperImpl.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/impl/bdbimpl/BdbTopicConfigMapperImpl.java
@@ -23,12 +23,15 @@ import com.sleepycat.persist.EntityCursor;
 import com.sleepycat.persist.EntityStore;
 import com.sleepycat.persist.PrimaryIndex;
 import com.sleepycat.persist.StoreConfig;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
 import org.apache.tubemq.corebase.TBaseConstants;
+import org.apache.tubemq.corebase.utils.ConcurrentHashSet;
 import org.apache.tubemq.server.common.exception.LoadMetaException;
 import org.apache.tubemq.server.common.utils.ProcessResult;
 import org.apache.tubemq.server.master.bdbstore.bdbentitys.BdbTopicConfEntity;
+import org.apache.tubemq.server.master.metastore.DataOpErrCode;
 import org.apache.tubemq.server.master.metastore.dao.entity.TopicConfEntity;
 import org.apache.tubemq.server.master.metastore.dao.mapper.TopicConfigMapper;
 import org.slf4j.Logger;
@@ -38,14 +41,20 @@ import org.slf4j.LoggerFactory;
 
 public class BdbTopicConfigMapperImpl implements TopicConfigMapper {
 
-
     private static final Logger logger =
             LoggerFactory.getLogger(BdbTopicConfigMapperImpl.class);
-
 
     // Topic configure store
     private EntityStore topicConfStore;
     private PrimaryIndex<String/* recordKey */, BdbTopicConfEntity> topicConfIndex;
+    // data cache
+    private ConcurrentHashMap<String/* recordKey */, TopicConfEntity> topicConfCache =
+            new ConcurrentHashMap<>();
+    private ConcurrentHashMap<Integer/* brokerId */, ConcurrentHashSet<String>>
+            topicConfBrokerCacheIndex = new ConcurrentHashMap<>();
+    private ConcurrentHashMap<String/* topicName */, ConcurrentHashSet<String> >
+            topicConfTopicNameCacheIndex = new ConcurrentHashMap<>();
+
 
 
     public BdbTopicConfigMapperImpl(ReplicatedEnvironment repEnv, StoreConfig storeConfig) {
@@ -68,9 +77,8 @@ public class BdbTopicConfigMapperImpl implements TopicConfigMapper {
     }
 
     @Override
-    public void loadConfig(ProcessResult result) throws LoadMetaException {
+    public void loadConfig() throws LoadMetaException {
         long count = 0L;
-        Map<String, TopicConfEntity> metaDataMap = new HashMap<>();
         EntityCursor<BdbTopicConfEntity> cursor = null;
         logger.info("[BDB Impl] load topic configure start...");
         try {
@@ -80,13 +88,11 @@ public class BdbTopicConfigMapperImpl implements TopicConfigMapper {
                     logger.warn("[BDB Impl] found Null data while loading topic configure!");
                     continue;
                 }
-                TopicConfEntity memEntity =
-                        new TopicConfEntity(bdbEntity);
-                metaDataMap.put(memEntity.getRecordKey(), memEntity);
+                TopicConfEntity memEntity = new TopicConfEntity(bdbEntity);
+                addOrUpdCacheRecord(memEntity);
                 count++;
             }
             logger.info("[BDB Impl] total topic configure records are {}", count);
-            result.setSuccResult(metaDataMap);
         } catch (Exception e) {
             logger.error("[BDB Impl] load topic configure failure ", e);
             throw new LoadMetaException(e.getMessage());
@@ -98,6 +104,77 @@ public class BdbTopicConfigMapperImpl implements TopicConfigMapper {
         logger.info("[BDB Impl] load topic configure successfully...");
     }
 
+    @Override
+    public boolean addTopicConf(TopicConfEntity memEntity, ProcessResult result) {
+        TopicConfEntity curEntity =
+                topicConfCache.get(memEntity.getRecordKey());
+        if (curEntity != null) {
+            result.setFailResult(DataOpErrCode.DERR_EXISTED.getCode(),
+                    new StringBuilder(TBaseConstants.BUILDER_DEFAULT_SIZE)
+                            .append("The topic configure ").append(memEntity.getRecordKey())
+                            .append("'s configure already exists, please delete it first!")
+                            .toString());
+            return result.isSuccess();
+        }
+        if (putTopicConfig2Bdb(memEntity, result)) {
+            addOrUpdCacheRecord(memEntity);
+        }
+        return result.isSuccess();
+    }
+
+    @Override
+    public boolean updTopicConf(TopicConfEntity memEntity, ProcessResult result) {
+        TopicConfEntity curEntity =
+                topicConfCache.get(memEntity.getRecordKey());
+        if (curEntity == null) {
+            result.setFailResult(DataOpErrCode.DERR_NOT_EXIST.getCode(),
+                    new StringBuilder(TBaseConstants.BUILDER_DEFAULT_SIZE)
+                            .append("The topic configure ").append(memEntity.getRecordKey())
+                            .append("'s configure is not exists, please add record first!")
+                            .toString());
+            return result.isSuccess();
+        }
+        if (curEntity.equals(memEntity)) {
+            result.setFailResult(DataOpErrCode.DERR_UNCHANGED.getCode(),
+                    new StringBuilder(TBaseConstants.BUILDER_DEFAULT_SIZE)
+                            .append("The topic configure ").append(memEntity.getRecordKey())
+                            .append("'s configure have not changed, please delete it first!")
+                            .toString());
+            return result.isSuccess();
+        }
+        if (putTopicConfig2Bdb(memEntity, result)) {
+            addOrUpdCacheRecord(memEntity);
+        }
+        return result.isSuccess();
+    }
+
+    @Override
+    public boolean delTopicConf(String recordKey) {
+        TopicConfEntity curEntity =
+                topicConfCache.get(recordKey);
+        if (curEntity == null) {
+            return true;
+        }
+        delTopicConfigFromBdb(recordKey);
+        delCacheRecord(recordKey);
+        return true;
+    }
+
+    @Override
+    public List<TopicConfEntity> getTopicConf(TopicConfEntity qryEntity) {
+        List<TopicConfEntity> retEntitys = new ArrayList<>();
+        if (qryEntity == null) {
+            retEntitys.addAll(topicConfCache.values());
+        } else {
+            for (TopicConfEntity entity : topicConfCache.values()) {
+                if (entity.isMatched(qryEntity)) {
+                    retEntitys.add(entity);
+                }
+            }
+        }
+        return retEntitys;
+    }
+
     /**
      * Put topic configure info into bdb store
      *
@@ -105,8 +182,7 @@ public class BdbTopicConfigMapperImpl implements TopicConfigMapper {
      * @param result process result with old value
      * @return
      */
-    @Override
-    public boolean putTopicConfig(TopicConfEntity memEntity, ProcessResult result) {
+    private boolean putTopicConfig2Bdb(TopicConfEntity memEntity, ProcessResult result) {
         BdbTopicConfEntity retData = null;
         BdbTopicConfEntity bdbEntity =
                 memEntity.buildBdbTopicConfEntity();
@@ -114,17 +190,17 @@ public class BdbTopicConfigMapperImpl implements TopicConfigMapper {
             retData = topicConfIndex.put(bdbEntity);
         } catch (Throwable e) {
             logger.error("[BDB Impl] put topic configure failure ", e);
-            result.setFailResult(new StringBuilder(TBaseConstants.BUILDER_DEFAULT_SIZE)
-                    .append("Put topic configure failure: ")
-                    .append(e.getMessage()).toString());
+            result.setFailResult(DataOpErrCode.DERR_STORE_ABNORMAL.getCode(),
+                    new StringBuilder(TBaseConstants.BUILDER_DEFAULT_SIZE)
+                            .append("Put topic configure failure: ")
+                            .append(e.getMessage()).toString());
             return result.isSuccess();
         }
         result.setSuccResult(retData == null);
         return result.isSuccess();
     }
 
-    @Override
-    public boolean delTopicConfig(String recordKey) {
+    private boolean delTopicConfigFromBdb(String recordKey) {
         try {
             topicConfIndex.delete(recordKey);
         } catch (Throwable e) {
@@ -134,4 +210,58 @@ public class BdbTopicConfigMapperImpl implements TopicConfigMapper {
         return true;
     }
 
+    private void delCacheRecord(String recordKey) {
+        TopicConfEntity curEntity = topicConfCache.get(recordKey);
+        if (curEntity == null) {
+            return;
+        }
+        // add topic index
+        ConcurrentHashSet<String> keySet =
+                topicConfTopicNameCacheIndex.get(curEntity.getTopicName());
+        if (keySet != null) {
+            keySet.remove(recordKey);
+            if (keySet.isEmpty()) {
+                topicConfTopicNameCacheIndex.remove(curEntity.getTopicName());
+            }
+        }
+        // delete brokerId index
+        keySet = topicConfBrokerCacheIndex.remove(curEntity.getBrokerId());
+        if (keySet != null) {
+            keySet.remove(recordKey);
+            if (keySet.isEmpty()) {
+                topicConfBrokerCacheIndex.remove(curEntity.getBrokerId());
+            }
+        }
+    }
+
+    private void addOrUpdCacheRecord(TopicConfEntity entity) {
+        topicConfCache.put(entity.getRecordKey(), entity);
+        // add topic index map
+        ConcurrentHashSet<String> keySet =
+                topicConfTopicNameCacheIndex.get(entity.getTopicName());
+        if (keySet == null) {
+            ConcurrentHashSet<String> tmpSet = new ConcurrentHashSet<>();
+            keySet = topicConfTopicNameCacheIndex.putIfAbsent(entity.getTopicName(), tmpSet);
+            if (keySet == null) {
+                keySet = tmpSet;
+            }
+        }
+        keySet.add(entity.getRecordKey());
+        // add brokerId index map
+        keySet = topicConfBrokerCacheIndex.get(entity.getBrokerId());
+        if (keySet == null) {
+            ConcurrentHashSet<String> tmpSet = new ConcurrentHashSet<>();
+            keySet = topicConfBrokerCacheIndex.putIfAbsent(entity.getBrokerId(), tmpSet);
+            if (keySet == null) {
+                keySet = tmpSet;
+            }
+        }
+        keySet.add(entity.getRecordKey());
+    }
+
+    private void clearCacheData() {
+        topicConfTopicNameCacheIndex.clear();
+        topicConfBrokerCacheIndex.clear();
+        topicConfCache.clear();
+    }
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/keepalive/AliveObserver.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/keepalive/AliveObserver.java
@@ -15,25 +15,12 @@
  * limitations under the License.
  */
 
-package org.apache.tubemq.server.master.metastore.dao.mapper;
 
-import java.util.Map;
-import org.apache.tubemq.server.common.utils.ProcessResult;
-import org.apache.tubemq.server.master.metastore.dao.entity.GroupConfigEntity;
+package org.apache.tubemq.server.master.metastore.keepalive;
 
+public interface AliveObserver {
 
-
-public interface GroupConfigMapper extends AbstractMapper {
-
-    boolean addGroupConf(GroupConfigEntity entity, ProcessResult result);
-
-    boolean updGroupConf(GroupConfigEntity entity, ProcessResult result);
-
-    boolean delGroupConf(String groupName);
-
-    GroupConfigEntity getGroupConf(String groupName);
-
-    Map<String, GroupConfigEntity> getGroupConf(GroupConfigEntity qryEntity);
+    void clearCacheData();
 
 
 }

--- a/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/keepalive/KeepAlive.java
+++ b/tubemq-server/src/main/java/org/apache/tubemq/server/master/metastore/keepalive/KeepAlive.java
@@ -15,25 +15,26 @@
  * limitations under the License.
  */
 
-package org.apache.tubemq.server.master.metastore.dao.mapper;
+package org.apache.tubemq.server.master.metastore.keepalive;
 
-import java.util.Map;
-import org.apache.tubemq.server.common.utils.ProcessResult;
-import org.apache.tubemq.server.master.metastore.dao.entity.GroupConfigEntity;
-
+import java.net.InetSocketAddress;
+import org.apache.tubemq.server.master.bdbstore.MasterGroupStatus;
 
 
-public interface GroupConfigMapper extends AbstractMapper {
 
-    boolean addGroupConf(GroupConfigEntity entity, ProcessResult result);
+public interface KeepAlive {
 
-    boolean updGroupConf(GroupConfigEntity entity, ProcessResult result);
+    boolean isMasterNow();
 
-    boolean delGroupConf(String groupName);
+    long getMasterSinceTime();
 
-    GroupConfigEntity getGroupConf(String groupName);
+    InetSocketAddress getMasterAddress();
 
-    Map<String, GroupConfigEntity> getGroupConf(GroupConfigEntity qryEntity);
+    boolean isPrimaryNodeActive();
 
+    void transferMaster() throws Exception;
 
+    void registerObserver(AliveObserver eventObserver);
+
+    MasterGroupStatus getMasterGroupStatus(boolean isFromHeartbeat);
 }


### PR DESCRIPTION
1. Add data cache processing of BDB metadatas;
2. Adjust Mapper's interface collection
3. Add equals and matching interface for each Entity class